### PR TITLE
convert to use get_or_create

### DIFF
--- a/entity/src/contentkey.rs
+++ b/entity/src/contentkey.rs
@@ -28,7 +28,7 @@ pub enum Relation {
     ContentAudit,
 }
 
-pub async fn get_or_create(content_key_raw: &dyn ContentKey, conn: &DatabaseConnection) -> Model {
+pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseConnection) -> Model {
     // First try to lookup an existing entry.
     let content_key = Entity::find()
         .filter(Column::ContentKey.eq(content_key_raw.encode()))

--- a/glados-core/src/types.rs
+++ b/glados-core/src/types.rs
@@ -9,10 +9,17 @@ pub struct BlockHeaderContentKey {
 pub trait ContentKey {
     fn encode(&self) -> Vec<u8>;
 
+    fn hex_encode(&self) -> String {
+        hex::encode(self.encode())
+    }
+
     fn content_id(&self) -> H256;
 }
 
 impl BlockHeaderContentKey {}
+
+unsafe impl Send for BlockHeaderContentKey {}
+unsafe impl Sync for BlockHeaderContentKey {}
 
 impl ContentKey for BlockHeaderContentKey {
     fn encode(&self) -> Vec<u8> {
@@ -44,6 +51,20 @@ mod tests {
 
         let content_key = BlockHeaderContentKey { hash: block_hash };
         assert_eq!(content_key.hash.as_bytes(), raw_hash);
+    }
+
+    #[test]
+    fn test_block_header_hex_encode() {
+        let raw_hash =
+            hex::decode("d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d")
+                .unwrap();
+        let block_hash = H256::from_slice(&raw_hash);
+
+        let content_key = BlockHeaderContentKey { hash: block_hash };
+        assert_eq!(
+            content_key.hex_encode(),
+            "d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+        );
     }
 
     #[test]

--- a/glados-core/src/types.rs
+++ b/glados-core/src/types.rs
@@ -63,7 +63,7 @@ mod tests {
         let content_key = BlockHeaderContentKey { hash: block_hash };
         assert_eq!(
             content_key.hex_encode(),
-            "d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+            "00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
         );
     }
 


### PR DESCRIPTION
Convert the `glados-monitor` script to use the `get_or_create` function introduced in #10 