### PR TITLE
glados-monitor: `continue` checking for new blocks instead of `break`ing out of loop

### DIFF
--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -70,9 +70,6 @@ async fn follow_chain_head(
             tx.send(block_number)
                 .await
                 .expect("Failed to send new block number");
-            if block_number > start_block_number + 2 {
-                continue;
-            }
         } else {
             debug!(head.number=?block_number, "head unchanged");
         }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -71,7 +71,7 @@ async fn follow_chain_head(
                 .await
                 .expect("Failed to send new block number");
             if block_number > start_block_number + 2 {
-                break;
+                continue;
             }
         } else {
             debug!(head.number=?block_number, "head unchanged");


### PR DESCRIPTION
`glados-monitor` stopped finding new blocks after 3-4 blocks because it was hitting this `break`