### PR TITLE
Error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ In most cases, you will want to set the environment variable `RUST_LOG` to enabl
 
 The `glados-monitor` crate can be run as follows to populate a local database with content ids.
 
-The CLI needs a DATABASE_URL to know what relational database to connect to, as well as an HTTP_PROVIDER_URI to connect to an Ethereum JSON-RPC provider.
+The CLI needs a DATABASE_URL to know what relational database to connect to, as well as an HTTP_PROVIDER_URI to connect to an Ethereum JSON-RPC provider (not a Portal node).
 
 ```
 $ cargo run -p glados-monitor -- --database-url <DATABASE_URL> follow-head --provider-url <HTTP_PROVIDER_URI>
 ```
-
+For example, if an Ethereum execution client is running on localhost port 8545:
+```
+$ cargo run -p glados-monitor -- --database-url sqlite::memory: follow-head --provider-url http://127.0.0.1:8545
+```
 #### Importing the pre-merge accumulators
 
 The pre-merge epoch accumulators can be found here: https://github.com/njgheorghita/portal-accumulators

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In most cases, you will want to set the environment variable `RUST_LOG` to enabl
 
 The `glados-monitor` crate can be run as follows to populate a local database with content ids.
 
-The CLI needs a DATABASE_URL to know what relational database to connect to, as well as an HTTP_PROVIDER_URI to connect to an Ethereum JSON-RPC provider (not a Portal node).
+The CLI needs a DATABASE_URL to know what relational database to connect to, as well as an HTTP_PROVIDER_URI to connect to an Ethereum JSON-RPC provider (not a portal node).
 
 ```
 $ cargo run -p glados-monitor -- --database-url <DATABASE_URL> follow-head --provider-url <HTTP_PROVIDER_URI>

--- a/entity/src/contentkey.rs
+++ b/entity/src/contentkey.rs
@@ -37,7 +37,10 @@ pub enum Relation {
     ContentAudit,
 }
 
-pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseConnection) -> Result<Model, DbErr> {
+pub async fn get_or_create(
+    content_key_raw: &impl ContentKey,
+    conn: &DatabaseConnection,
+) -> Result<Model, DbErr> {
     // First try to lookup an existing entry.
     let content_key = Entity::find()
         .filter(Column::ContentKey.eq(content_key_raw.encode()))
@@ -46,7 +49,7 @@ pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseCon
 
     if let Some(content_key) = content_key {
         // If there is an existing record, return it
-        return Ok(content_key)
+        return Ok(content_key);
     }
     let content_id_raw = content_key_raw.content_id();
     let content_id = contentid::get_or_create(&content_id_raw, conn).await;
@@ -57,9 +60,7 @@ pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseCon
         content_key: Set(content_key_raw.encode()),
         created_at: Set(chrono::offset::Utc::now()),
     };
-    Ok(content_key
-        .insert(conn)
-        .await?)
+    content_key.insert(conn).await
 }
 
 pub async fn get(content_key: &impl ContentKey, conn: &DatabaseConnection) -> Option<Model> {

--- a/entity/src/contentkey.rs
+++ b/entity/src/contentkey.rs
@@ -37,32 +37,29 @@ pub enum Relation {
     ContentAudit,
 }
 
-pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseConnection) -> Model {
+pub async fn get_or_create(content_key_raw: &impl ContentKey, conn: &DatabaseConnection) -> Result<Model, DbErr> {
     // First try to lookup an existing entry.
     let content_key = Entity::find()
         .filter(Column::ContentKey.eq(content_key_raw.encode()))
         .one(conn)
-        .await
-        .unwrap(); // TODO: is there a better option than `unwrap` here?
+        .await?;
 
     if let Some(content_key) = content_key {
         // If there is an existing record, return it
-        content_key
-    } else {
-        let content_id_raw = content_key_raw.content_id();
-        let content_id = contentid::get_or_create(&content_id_raw, conn).await;
-        // If no record exists, create one and return it
-        let content_key = ActiveModel {
-            id: NotSet,
-            content_id: Set(content_id.id),
-            content_key: Set(content_key_raw.encode()),
-            created_at: Set(chrono::offset::Utc::now()),
-        };
-        content_key
-            .insert(conn)
-            .await
-            .expect("Error inserting new content key")
+        return Ok(content_key)
     }
+    let content_id_raw = content_key_raw.content_id();
+    let content_id = contentid::get_or_create(&content_id_raw, conn).await;
+    // If no record exists, create one and return it
+    let content_key = ActiveModel {
+        id: NotSet,
+        content_id: Set(content_id.id),
+        content_key: Set(content_key_raw.encode()),
+        created_at: Set(chrono::offset::Utc::now()),
+    };
+    Ok(content_key
+        .insert(conn)
+        .await?)
 }
 
 pub async fn get(content_key: &impl ContentKey, conn: &DatabaseConnection) -> Option<Model> {

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -190,13 +190,13 @@ async fn test_contentkey_get_or_create() -> Result<(), DbErr> {
     assert_eq!(contentid::Entity::find().count(&conn).await?, 0);
     assert_eq!(contentkey::Entity::find().count(&conn).await?, 0);
 
-    let content_key_a = contentkey::get_or_create(&header_content_key, &conn).await;
+    let content_key_a = contentkey::get_or_create(&header_content_key, &conn).await.unwrap();
 
     // Ensure our database now has entries for both
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);
     assert_eq!(contentkey::Entity::find().count(&conn).await?, 1);
 
-    let content_key_b = contentkey::get_or_create(&header_content_key, &conn).await;
+    let content_key_b = contentkey::get_or_create(&header_content_key, &conn).await.unwrap();
 
     // Ensure the existing entries were found
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -190,13 +190,17 @@ async fn test_contentkey_get_or_create() -> Result<(), DbErr> {
     assert_eq!(contentid::Entity::find().count(&conn).await?, 0);
     assert_eq!(contentkey::Entity::find().count(&conn).await?, 0);
 
-    let content_key_a = contentkey::get_or_create(&header_content_key, &conn).await.unwrap();
+    let content_key_a = contentkey::get_or_create(&header_content_key, &conn)
+        .await
+        .unwrap();
 
     // Ensure our database now has entries for both
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);
     assert_eq!(contentkey::Entity::find().count(&conn).await?, 1);
 
-    let content_key_b = contentkey::get_or_create(&header_content_key, &conn).await.unwrap();
+    let content_key_b = contentkey::get_or_create(&header_content_key, &conn)
+        .await
+        .unwrap();
 
     // Ensure the existing entries were found
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -170,7 +170,7 @@ where
         let resp = self.make_request(req);
 
         match resp {
-            Err(err) => format!("error: {}", err),
+            Err(err) => format!("error: {err}"),
             Ok(value) => value.result.to_string(),
         }
     }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -100,69 +100,70 @@ async fn retrieve_new_blocks(
             continue
         };
 
-        // If we got a block back
-        if let Some(blk) = block {
-            // And if that block has a hash
-            if let Some(block_hash) = blk.hash {
-                info!(
-                    block.hash=?block_hash,
-                    block.number=?block_number_to_retrieve,
-                    "received block",
-                );
-
-                // Create block header content key
-                let raw_header_content_key = BlockHeaderContentKey {
-                    hash: H256::from_slice(block_hash.as_bytes()),
-                };
-
-                debug!(
-                    content.key=raw_header_content_key.hex_encode(),
-                    content.id=?raw_header_content_key.content_id(),
-                    content.kind="block-header",
-                    "Creating content database record",
-                );
-
-                if let Err(e) = contentkey::get_or_create(&raw_header_content_key, &conn).await {
-                    error!("Failed to get or create raw_header_content_key {raw_header_content_key} (error: {e}")
-                }
-
-                // Create block body content key
-                let raw_body_content_key = BlockBodyContentKey {
-                    hash: H256::from_slice(block_hash.as_bytes()),
-                };
-
-                debug!(
-                    content.key=raw_body_content_key.hex_encode(),
-                    content.id=?raw_body_content_key.content_id(),
-                    content.kind="block-body",
-                    "Creating content database record",
-                );
-
-                if let Err(e) = contentkey::get_or_create(&raw_body_content_key, &conn).await {
-                    error!("Failed to get or create raw_body_content_key {raw_body_content_key} (error: {e}")
-                }
-
-                // Create block receipts content key
-                let raw_receipts_content_key = BlockReceiptsContentKey {
-                    hash: H256::from_slice(block_hash.as_bytes()),
-                };
-
-                debug!(
-                    content.key=raw_receipts_content_key.hex_encode(),
-                    content.id=?raw_receipts_content_key.content_id(),
-                    content.kind="block-receipts",
-                    "Creating content database record",
-                );
-
-                if let Err(e) = contentkey::get_or_create(&raw_receipts_content_key, &conn).await {
-                    error!("Failed to get or create raw_receipts_content_key {raw_receipts_content_key} (error: {e}")
-                }
-            }
-        } else {
+        let Some(blk) = block else {
             error!(
                 block.number=?block_number_to_retrieve,
                 "failure retrieving block",
             );
+            continue
+        };
+        let Some(block_hash) = blk.hash else {
+            error!("Block {:?} has no hash (skipping)", blk);
+            continue
+        };
+        
+        info!(
+            block.hash=?block_hash,
+            block.number=?block_number_to_retrieve,
+            "received block",
+        );
+
+        // Create block header content key
+        let raw_header_content_key = BlockHeaderContentKey {
+            hash: H256::from_slice(block_hash.as_bytes()),
+        };
+
+        debug!(
+            content.key=raw_header_content_key.hex_encode(),
+            content.id=?raw_header_content_key.content_id(),
+            content.kind="block-header",
+            "Creating content database record",
+        );
+
+        if let Err(e) = contentkey::get_or_create(&raw_header_content_key, &conn).await {
+            error!("Failed to get or create raw_header_content_key {raw_header_content_key} (error: {e}")
+        }
+
+        // Create block body content key
+        let raw_body_content_key = BlockBodyContentKey {
+            hash: H256::from_slice(block_hash.as_bytes()),
+        };
+
+        debug!(
+            content.key=raw_body_content_key.hex_encode(),
+            content.id=?raw_body_content_key.content_id(),
+            content.kind="block-body",
+            "Creating content database record",
+        );
+
+        if let Err(e) = contentkey::get_or_create(&raw_body_content_key, &conn).await {
+            error!("Failed to get or create raw_body_content_key {raw_body_content_key} (error: {e}")
+        }
+
+        // Create block receipts content key
+        let raw_receipts_content_key = BlockReceiptsContentKey {
+            hash: H256::from_slice(block_hash.as_bytes()),
+        };
+
+        debug!(
+            content.key=raw_receipts_content_key.hex_encode(),
+            content.id=?raw_receipts_content_key.content_id(),
+            content.kind="block-receipts",
+            "Creating content database record",
+        );
+
+        if let Err(e) = contentkey::get_or_create(&raw_receipts_content_key, &conn).await {
+            error!("Failed to get or create raw_receipts_content_key {raw_receipts_content_key} (error: {e}")
         }
     }
 }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -141,11 +141,11 @@ async fn store_content_key<T: ContentKey>(key: &T, name: &str, conn: &DatabaseCo
 
     if let Err(e) = contentkey::get_or_create(key, conn).await {
         error!(
-            "Failed to record {} key in db (key = {}, id = {}) (error: {})",
-            name,
-            key.hex_encode(),
-            key.content_id(),
-            e
+            content.key=key.hex_encode(),
+            content.id=?key.content_id(),
+            content.kind=name,
+            err=?e,
+            "Failed to create database record",
         );
     }
 }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -75,9 +75,9 @@ async fn follow_chain_head(
             new_head.number=?candidate_block_number,
             "new head",
         );
-        block_number = candidate_block_number;
-        if let Err(e) = tx.send(block_number).await {
-            warn!("Failed to send new block number {e}")
+        match tx.send(candidate_block_number).await {
+            Ok(_) => block_number = candidate_block_number,
+            Err(e) => warn!("Failed to send new block number {block_number} (error: {e})"),
         };
     }
 }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -14,10 +14,7 @@ use web3::types::BlockId;
 
 use ethereum_types::H256;
 
-use glados_core::types::{
-    BlockBodyContentKey, BlockHeaderContentKey, BlockReceiptsContentKey, ContentKey,
-    EpochAccumulatorContentKey,
-};
+use glados_core::types::{BlockHeaderContentKey, ContentKey, EpochAccumulatorContentKey};
 
 use entity::contentkey;
 
@@ -68,7 +65,7 @@ async fn follow_chain_head(
 
         if candidate_block_number <= block_number {
             debug!(head.number=?block_number, "head unchanged");
-            continue
+            continue;
         }
         info!(
             old_head.number=?block_number,
@@ -142,13 +139,20 @@ async fn store_content_key<T: ContentKey>(key: &T, name: &str, conn: &DatabaseCo
     );
 
     if let Err(e) = contentkey::get_or_create(key, conn).await {
-        error!("Failed to record {} key in db (key = {}, id = {}) (error: {})",
-        name, key.hex_encode(), key.content_id(), e);
+        error!(
+            "Failed to record {} key in db (key = {}, id = {}) (error: {})",
+            name,
+            key.hex_encode(),
+            key.content_id(),
+            e
+        );
     }
 }
 
-
-pub async fn import_pre_merge_accumulators(conn: DatabaseConnection, base_path: PathBuf) -> Result<(), DbErr> {
+pub async fn import_pre_merge_accumulators(
+    conn: DatabaseConnection,
+    base_path: PathBuf,
+) -> Result<(), DbErr> {
     info!(base_path = %base_path.as_path().display(), "Starting import of pre-merge accumulators");
 
     let mut entries = read_dir(base_path).await.unwrap();
@@ -195,7 +199,6 @@ pub async fn import_pre_merge_accumulators(conn: DatabaseConnection, base_path: 
                 "Skipping non-file path"
             );
         }
-
     }
     Ok(())
 }

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -1,3 +1,4 @@
+use migration::DbErr;
 use tokio::signal;
 use tokio::task;
 
@@ -15,7 +16,7 @@ use glados_monitor::{
 };
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), DbErr> {
     // Setup logging
     env_logger::init();
 
@@ -70,11 +71,14 @@ async fn main() {
             println!("Command completed, exiting");
         }
     }
+    Ok(())
 }
 
-async fn do_nothing() {}
+async fn do_nothing() -> Result<(), DbErr> {
+    Ok(())
+}
 
-async fn follow_head_command(conn: DatabaseConnection, provider_url: String) {
+async fn follow_head_command(conn: DatabaseConnection, provider_url: String) -> Result<(), DbErr> {
     //
     // Web3 Connection
     //
@@ -90,4 +94,5 @@ async fn follow_head_command(conn: DatabaseConnection, provider_url: String) {
     );
 
     run_glados_monitor(conn, w3).await;
+    Ok(())
 }

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -63,7 +63,7 @@ where
             Ok(html) => Html(html).into_response(),
             Err(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to render template. Error: {}", err),
+                format!("Failed to render template. Error: {err}"),
             )
                 .into_response(),
         }


### PR DESCRIPTION
## Description

Panic when running `glados-monitor` against a local execution node.
```sh
$ cargo run -p glados-monitor -- --database-url sqlite::memory: follow-head --provider-url http://127.0.0.1:8545
```
The panic occurred in `contentkey::get_or_create()`, where an `Entity::find` Result was `unwrap()`ed.

## Changes
### Monitor loops do not terminate
The `run_glados_monitor()` initiates two never-ending loops:
- `follow_chain_head()`
- `retrieve_new_blocks()`

Rather than allow those loops to fail when an error is encountered, the loops are allowed to continue. 

- Errors are logged
- Where the loop cannot proceed due to an error, a `continue` moves to the next cycle.

### Channel remains open

The `retrieve_new_blocks()` control loop was determined by a `while let` on the `channel.recv()`. 

After the first successful loop, the function terminated and the channel was closed. This was resolved
by replacing the `while` with a `loop`.

### Early terminations

Some conditions allow for a loop to be skipped early. Those were moved to `continue`s to reduce block
nesting.

### Grouping of `ContentKey` storing

The logic for storage of the three `ContentKey` types was moved to a function generic over that type.

## Unresolved

There is still an issue where the following function results in an `Error`
```rs
  let content_key = Entity::find()
      .filter(Column::ContentKey.eq(content_key_raw.encode()))
      .one(conn)
      .await?;
```
```sh
error: Query Error: error returned from database: (code: 1) no such table: content_key
```
I am not sure what this problem is. However rather than crashing glados, it runs its loops and logs the error.

### Additional changes
- Added example flag in docs to clarify that glados-monitor connects to 