### PR TITLE
fix: Don't skip db init for in-memory db

### DIFF
--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -36,31 +36,6 @@ async fn main() -> Result<(), DbErr> {
         "database connection established"
     );
 
-    let manager = SchemaManager::new(&conn);
-    let mut db_exists = true;
-    for t in [
-        "content_audit",
-        "content_id",
-        "content_key",
-        "node",
-        "record",
-    ] {
-        if !manager
-            .has_table(t)
-            .await
-            .expect("could not query database")
-        {
-            db_exists = false;
-        };
-    }
-
-    if !db_exists {
-        info!("creating new database tables");
-        Migrator::up(&conn, None)
-            .await
-            .expect("could not create new database tables");
-    }
-
     if cli.migrate {
         info!("running database migrations");
         Migrator::up(&conn, None).await.unwrap();

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -36,6 +36,19 @@ async fn main() -> Result<(), DbErr> {
         "database connection established"
     );
 
+    let manager = SchemaManager::new(&conn);
+    let mut db_exists = true;
+    for t in ["content_audit", "content_id", "content_key", "node", "record"] {
+        if !manager.has_table(t).await.expect("could not query database") {
+            db_exists = false;
+        };
+    }
+
+    if !db_exists {
+        info!("creating new database tables");
+        Migrator::up(&conn, None).await.expect("coult not create new database tables");
+    }
+
     if cli.migrate {
         info!("running database migrations");
         Migrator::up(&conn, None).await.unwrap();

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -38,7 +38,9 @@ async fn main() -> Result<(), DbErr> {
 
     if cli.migrate || cli.database_url == "sqlite::memory:" {
         info!("running database migrations");
-        Migrator::up(&conn, None).await.expect("Database migration failed");
+        Migrator::up(&conn, None)
+            .await
+            .expect("Database migration failed");
     }
 
     let task_handle = match &cli.command {

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), DbErr> {
 
     if cli.migrate || cli.database_url == "sqlite::memory:" {
         info!("running database migrations");
-        Migrator::up(&conn, None).await.unwrap();
+        Migrator::up(&conn, None).await.expect("Database migration failed");
     }
 
     let task_handle = match &cli.command {

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), DbErr> {
 
     if !db_exists {
         info!("creating new database tables");
-        Migrator::up(&conn, None).await.expect("coult not create new database tables");
+        Migrator::up(&conn, None).await.expect("could not create new database tables");
     }
 
     if cli.migrate {

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), DbErr> {
         "database connection established"
     );
 
-    if cli.migrate {
+    if cli.migrate || cli.database_url == "sqlite::memory:" {
         info!("running database migrations");
         Migrator::up(&conn, None).await.unwrap();
     }

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), DbErr> {
         "database connection established"
     );
 
-    if cli.migrate || cli.database_url == "sqlite::memory:" {
+    if cli.migrate {
         info!("running database migrations");
         Migrator::up(&conn, None).await.unwrap();
     }

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -36,8 +36,26 @@ async fn main() -> Result<(), DbErr> {
         "database connection established"
     );
 
-    if no_tables(&conn).await {
-        info!("No database tables present, creating new tables.");
+    let manager = SchemaManager::new(&conn);
+    let mut db_exists = true;
+    for t in [
+        "content_audit",
+        "content_id",
+        "content_key",
+        "node",
+        "record",
+    ] {
+        if !manager
+            .has_table(t)
+            .await
+            .expect("could not query database")
+        {
+            db_exists = false;
+        };
+    }
+
+    if !db_exists {
+        info!("creating new database tables");
         Migrator::up(&conn, None)
             .await
             .expect("could not create new database tables");
@@ -96,36 +114,4 @@ async fn follow_head_command(conn: DatabaseConnection, provider_url: String) -> 
 
     run_glados_monitor(conn, w3).await;
     Ok(())
-}
-
-/// Returns true if there are no tables in the database.
-///
-/// Useful if deciding whether to create a new database or not.
-///
-/// Rather than looking for individual tables (which may break
-/// if new tables are added/removed), this handles the search generally
-/// for the supported tables in Sea_Orm.
-async fn no_tables(db: &DatabaseConnection) -> bool {
-    // A statement finding all tables for the given backend.
-    let statement = match db.get_database_backend() {
-        backend @ DbBackend::MySql => {
-            let q = "SHOW TABLES";
-            warn!("This {backend:?} query to retrieve all tables is untested: {q}");
-            Statement::from_sql_and_values(backend, q, vec![])
-        }
-        backend @ DbBackend::Postgres => {
-            let q = "SELECT * FROM information_schema.tables WHERE table_schema='public';";
-            warn!("This {backend:?} query to retrieve all tables is untested: {q}");
-            Statement::from_sql_and_values(backend, q, vec![])
-        }
-        backend @ DbBackend::Sqlite => {
-            let q = "SELECT name FROM sqlite_master WHERE type='table';";
-            Statement::from_sql_and_values(backend, q, vec![])
-        }
-    };
-    JsonValue::find_by_statement(statement)
-        .all(db)
-        .await
-        .expect("Couldn't query database for tables")
-        .is_empty()
 }

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -38,15 +38,27 @@ async fn main() -> Result<(), DbErr> {
 
     let manager = SchemaManager::new(&conn);
     let mut db_exists = true;
-    for t in ["content_audit", "content_id", "content_key", "node", "record"] {
-        if !manager.has_table(t).await.expect("could not query database") {
+    for t in [
+        "content_audit",
+        "content_id",
+        "content_key",
+        "node",
+        "record",
+    ] {
+        if !manager
+            .has_table(t)
+            .await
+            .expect("could not query database")
+        {
             db_exists = false;
         };
     }
 
     if !db_exists {
         info!("creating new database tables");
-        Migrator::up(&conn, None).await.expect("could not create new database tables");
+        Migrator::up(&conn, None)
+            .await
+            .expect("could not create new database tables");
     }
 
     if cli.migrate {


### PR DESCRIPTION
### Description

No database is created for in-memory db as noted in #30 

### What was changed

- ~~Implements option 2 outlined in the issue by detecting if the in-memory argument was passed and a running db migration to create the tables.~~
- ~~Implements option 3 outlined in the issue by detecting if all of the expected tables exist, and if any are missing, runs `Migrator::up` to create the tables.~~
- Implements option 3 outlined in the issue. It detects if the database contains no tables, and if so runs `Migrator::up` to create the tables.

### Testing

This resolves the issue on `main` and also resolves the ("Unresolved") problem noted in #29