### PR TITLE
Prevent sqlx from logging queries

### DIFF
--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -1,7 +1,7 @@
 use tokio::signal;
 use tokio::task;
 
-use sea_orm::{Database, DatabaseConnection};
+use sea_orm::{Database, DatabaseConnection, ConnectOptions};
 
 use tracing::{debug, info};
 
@@ -32,7 +32,10 @@ async fn main() {
     //
     debug!(DATABASE_URL = &cli.database_url, "Connecting to database");
 
-    let conn = Database::connect(&cli.database_url)
+    let mut opt = ConnectOptions::new(cli.database_url.to_owned());
+    opt.sqlx_logging(false);
+
+    let conn = Database::connect(opt)
         .await
         .expect("Database connection failed");
 


### PR DESCRIPTION
### Description

Sea orm by default includes the sqlx logs. They contain information that verbose and redundant in the context of
glados logging. 

### Changes

Add configuration during database connection setup to disable sqlx logs
```rs
let mut opt = ConnectOptions::new(cli.database_url.to_owned());
    opt.sqlx_logging(false);
```

### Effect
`<id>` below is the full hexadecimal id.

Before:
```
Creating content database record content.key="<id>" content.id=<id> content.kind="block-body"
[<timestamp> ERROR sqlx::query] SELECT "content_key"."id", "content_key"."content_id", "content_key"."content_key", …; rows affected: 1, rows returned: 1, elapsed: 30.543µs
    
    SELECT
      "content_key"."id",
      "content_key"."content_id",
      "content_key"."content_key",
      "content_key"."created_at"
    FROM
      "content_key"
    WHERE
      "content_key"."id" = ?
    LIMIT
      ?
```
After, only the glados-based log remains:
```
Creating content database record content.key="<id>" content.id=<id> content.kind="block-body"
```
### Alternatives
Note that there is another option to apply a filter to the sqlx logs (`.sqlx_logging_level(level)`),
however the method did not behave as expected. It would still permit all logs through the filter, but relabel 
their log label to that which was passed in. 
