### PR TITLE
group and reorder crate imports

### DIFF
--- a/entity/src/contentaudit.rs
+++ b/entity/src/contentaudit.rs
@@ -1,9 +1,9 @@
+use std::i32;
+
 use chrono::{DateTime, Utc};
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 
 use glados_core::types::ContentKey;
-
-use std::i32;
 
 #[derive(Debug, Clone, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]

--- a/entity/src/contentid.rs
+++ b/entity/src/contentid.rs
@@ -1,7 +1,6 @@
+use ethereum_types::H256;
 use sea_orm::entity::prelude::*;
 use sea_orm::{NotSet, Set};
-
-use ethereum_types::H256;
 
 #[derive(Clone, Debug, Eq, PartialEq, DeriveEntityModel)]
 #[sea_orm(table_name = "content_id")]

--- a/entity/src/contentkey.rs
+++ b/entity/src/contentkey.rs
@@ -1,7 +1,6 @@
+use chrono::{DateTime, Utc};
 use sea_orm::entity::prelude::*;
 use sea_orm::{NotSet, Set};
-
-use chrono::{DateTime, Utc};
 
 use glados_core::types::ContentKey;
 

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -1,23 +1,17 @@
 #![allow(unused_imports)]
 #[cfg(test)]
 use chrono::prelude::*;
-
+use ethereum_types::H256;
 use sea_orm::entity::prelude::*;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Database, DbConn, DbErr, EntityTrait, NotSet, PaginatorTrait,
     QueryFilter, Set,
 };
 
-use ethereum_types::H256;
-
+use glados_core::types::BlockHeaderContentKey;
 use migration::{Migrator, MigratorTrait};
 
-use glados_core::types::BlockHeaderContentKey;
-
-use crate::contentaudit;
-use crate::contentid;
-use crate::contentkey;
-use crate::node;
+use crate::{contentaudit, contentid, contentkey, node};
 
 #[allow(dead_code)]
 async fn setup_database() -> Result<DbConn, DbErr> {

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -1,17 +1,18 @@
 use std::path::PathBuf;
 
 use ethereum_types::H256;
+use sea_orm::{DatabaseConnection, EntityTrait, QueryOrder, QuerySelect};
+use tokio::{
+    sync::mpsc,
+    time::{interval, Duration},
+};
 use tracing::{debug, error, info};
 
-use sea_orm::{DatabaseConnection, EntityTrait, QueryOrder, QuerySelect};
-
-use tokio::sync::mpsc;
-use tokio::time::{interval, Duration};
-
-use glados_core::jsonrpc::PortalClient;
-use glados_core::types::{BlockHeaderContentKey, ContentKey};
-
 use entity::{contentaudit, contentkey};
+use glados_core::{
+    jsonrpc::PortalClient,
+    types::{BlockHeaderContentKey, ContentKey},
+};
 
 pub mod cli;
 

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -1,14 +1,11 @@
-use sea_orm::Database;
-
-use tracing::{debug, info};
-
-use clap::Parser;
-
 use std::path::PathBuf;
 
-use migration::{Migrator, MigratorTrait};
+use clap::Parser;
+use sea_orm::Database;
+use tracing::{debug, info};
 
 use glados_audit::{cli::Args, run_glados_audit};
+use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() {

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -9,14 +9,13 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use serde_json::value::{to_raw_value, RawValue};
 
+use discv5::enr::CombinedKey;
+use ethereum_types::{H256, U256};
 use thiserror::Error;
 
-use ethereum_types::{H256, U256};
-
-use discv5::enr::CombinedKey;
-type Enr = discv5::enr::Enr<CombinedKey>;
-
 use crate::types::ContentKey;
+
+type Enr = discv5::enr::Enr<CombinedKey>;
 
 //
 // JSON RPC Client

--- a/glados-core/src/types.rs
+++ b/glados-core/src/types.rs
@@ -1,8 +1,7 @@
 pub(crate) use std::fmt;
 
-use sha2::{Digest, Sha256};
-
 use ethereum_types::H256;
+use sha2::{Digest, Sha256};
 
 pub enum ContentKeySelector {
     BlockHeader,

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -1,22 +1,15 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use migration::DbErr;
-use tracing::{debug, error, info, warn};
-
+use ethereum_types::H256;
 use sea_orm::DatabaseConnection;
-
-use tokio::fs::read_dir;
-use tokio::sync::mpsc;
-use tokio::time::sleep;
-
+use tokio::{fs::read_dir, sync::mpsc, time::sleep};
+use tracing::{debug, error, info, warn};
 use web3::types::BlockId;
 
-use ethereum_types::H256;
-
-use glados_core::types::{BlockHeaderContentKey, ContentKey, EpochAccumulatorContentKey};
-
 use entity::contentkey;
+use glados_core::types::{BlockHeaderContentKey, ContentKey, EpochAccumulatorContentKey};
+use migration::DbErr;
 
 pub mod cli;
 

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -1,19 +1,13 @@
-use migration::DbErr;
-use tokio::signal;
-use tokio::task;
-
-use sea_orm::{Database, DatabaseConnection};
-
-use tracing::{debug, info};
-
 use clap::Parser;
-
-use migration::{Migrator, MigratorTrait};
+use sea_orm::{Database, DatabaseConnection};
+use tokio::{signal, task};
+use tracing::{debug, info};
 
 use glados_monitor::{
     cli::{Cli, Commands},
     import_pre_merge_accumulators, run_glados_monitor,
 };
+use migration::{DbErr, Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() -> Result<(), DbErr> {

--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -6,7 +6,6 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-
 use tower_http::services::ServeDir;
 
 pub mod cli;

--- a/glados-web/src/main.rs
+++ b/glados-web/src/main.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
+use clap::Parser;
 use sea_orm::Database;
 
-use clap::Parser;
-
-use migration::{Migrator, MigratorTrait};
-
 use glados_web::{cli::Args, run_glados_web, state::State};
+use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() {

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -1,18 +1,14 @@
 use std::io;
 use std::sync::Arc;
 
-use axum::http::StatusCode;
 use axum::{
     extract::{Extension, Path},
+    http::StatusCode,
     response::IntoResponse,
 };
-
 use sea_orm::{ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect};
 
-use entity::contentaudit;
-use entity::contentid;
-use entity::contentkey;
-use entity::node;
+use entity::{contentaudit, contentid, contentkey, node};
 
 use crate::state::State;
 use crate::templates::{

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -4,10 +4,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
 };
 
-use entity::contentaudit;
-use entity::contentid;
-use entity::contentkey;
-use entity::node;
+use entity::{contentaudit, contentid, contentkey, node};
 
 #[derive(Template)]
 #[template(path = "index.html")]


### PR DESCRIPTION
### Description

The imports were a mixture of styles. 

### Changes

Imports are 
- moved to sections, ordered as follows:
    - std
    - external
    - workspace members
    - module 
- alphabetical within each section
- grouped by Crate 
    - as in https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#imports_granularity (which is still nightly-only)
    - with the exception of any `prelude::*`, which are separate for clarity.

