### PR TITLE
add clarification and description to guide

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -10,21 +10,22 @@ This example uses the following:
     - `glados-monitor`
     - `glados-audit`
     - `glados-web`
-- "`machine-b`"(with display)
+- "`machine-b`" (with display)
     - Browser listening to `glados-web`
 
 All commands are issued on `machine-a` unless otherwise stated.
 
 Important notes:
 - If `glados-monitor`, `glados-audit` and `glados-web` are in `sqlite::memory:`-mode they won't be able to share a database. In-memory databases are ephemeral and only persist as long as the process is running.
+- `glados-audit` does not support `http` communication (must start `trin` with `--web3-transport ipc`)
 
 Start Ethereum execution client (not covered here).
 
 Make an empty database file for glados.
 ```command
-$ touch /tmp/glados-ephemeral.sqlite
+$ touch /path/to/database.sqlite
 ```
-Start trin (requires https://github.com/ethereum/trin/pull/510), see repo for latest docs.
+Start trin (see [docs](https://github.com/ethereum/trin/blob/master/docs/ubuntu_guide.md)
 ```command
 ~/trin$ RUST_LOG=debug cargo run -p trin -- \
     --no-stun \
@@ -34,23 +35,28 @@ Start trin (requires https://github.com/ethereum/trin/pull/510), see repo for la
     --discovery-port 9009 \
     --bootnodes default
 ```
-Start `glados-monitor` (requires https://github.com/pipermerriam/glados/pull/31)
+Start `glados-monitor`, which uses chain data from the execution node and stores that in the
+glados database. For an empty database file, the `--migration` flag triggers
+database table creation.
 ```command
 ~/glados$ RUST_LOG=glados_monitor=debug cargo run -p glados-monitor -- \
-    --database-url sqlite:////tmp/glados-ephemeral.sqlite \
+    --migrate \
+    --database-url sqlite:////path/to/database.sqlite \
     follow-head \
     --provider-url http://127.0.0.1:8545
 ```
-Start `glados-audit`
+Start `glados-audit`, which takes monitoring data from the glados database,
+checks if `trin` has it, then records the outcome in the glados database.
 ```command
 ~/glados$ RUST_LOG=debug cargo run -p glados-audit -- \
-    --ipc-path /tmp/trin-jsonrpc.ipc \
-    --database-url sqlite:////tmp/glados-ephemeral.sqlite
+    --ipc-path /path/to/trin-jsonrpc.ipc \
+    --database-url sqlite:////path/to/database.sqlite
 ```
-Start `glados-web`
+Start `glados-web`, which takes audit data from the glados database and serves
+that for viewing.
 ```command
 ~/glados$ RUST_LOG=debug cargo run -p glados-web -- \
-    --database-url sqlite:////tmp/glados-ephemeral.sqlite
+    --database-url sqlite:////path/to/database.sqlite
 ```
 
 On `machine-b`, listen for `glados-web`


### PR DESCRIPTION
### Description

Adds a few additional descriptions to `SETUP_GUIDE.md`

### Changes
- Clarify that the use of `/tmp` for db files is vulnerable on reboot
- Remove the requirement on pr 31 (db check for tables to determine init) and show use of `--migrate` flag for new empty db creation
- Descriptions for what source/dest each binary has for data