### PR TITLE
use anyhow for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
 name = "entity"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "enr 0.7.0",
  "ethereum-types 0.14.0",
@@ -1664,6 +1665,7 @@ dependencies = [
 name = "glados-audit"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap 4.0.26",
  "entity",
  "env_logger",
@@ -1682,6 +1684,7 @@ dependencies = [
 name = "glados-core"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "discv5",
  "env_logger",
  "ethereum-types 0.14.0",
@@ -1699,6 +1702,7 @@ dependencies = [
 name = "glados-monitor"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap 4.0.26",
  "entity",
  "env_logger",
@@ -1717,6 +1721,7 @@ dependencies = [
 name = "glados-web"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "askama",
  "axum",
  "clap 4.0.26",

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.68"
 chrono = "0.4.22"
 enr = "0.7.0"
 ethereum-types = "0.14.0"

--- a/entity/src/contentaudit.rs
+++ b/entity/src/contentaudit.rs
@@ -1,5 +1,6 @@
 use std::i32;
 
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 
@@ -66,16 +67,15 @@ pub async fn create(
 pub async fn get_audits<'b, T: OverlayContentKey>(
     content_key: &'b T,
     conn: &DatabaseConnection,
-) -> Vec<Model>
+) -> Result<Vec<Model>>
 where
     Vec<u8>: From<&'b T>,
 {
     let encoded: Vec<u8> = content_key.into();
-    Entity::find()
+    Ok(Entity::find()
         .filter(Column::ContentKey.eq(encoded))
         .all(conn)
-        .await
-        .unwrap()
+        .await?)
 }
 
 impl Related<super::contentkey::Entity> for Entity {

--- a/entity/src/test.rs
+++ b/entity/src/test.rs
@@ -113,7 +113,9 @@ async fn test_contentid_as_hash() -> Result<(), DbErr> {
         25, 26, 27, 28, 29, 30, 31,
     ];
     let content_id_hash = H256::from_slice(&content_id_raw);
-    let content_id = contentid::get_or_create(&content_id_hash, &conn).await;
+    let content_id = contentid::get_or_create(&content_id_hash, &conn)
+        .await
+        .unwrap();
 
     // ensure our database is empty
     assert_eq!(content_id.as_hash(), content_id_hash);
@@ -130,7 +132,9 @@ async fn test_contentid_as_hex() -> Result<(), DbErr> {
         25, 26, 27, 28, 29, 30, 31,
     ];
     let content_id_hash = H256::from_slice(&content_id_raw);
-    let content_id = contentid::get_or_create(&content_id_hash, &conn).await;
+    let content_id = contentid::get_or_create(&content_id_hash, &conn)
+        .await
+        .unwrap();
 
     // ensure our database is empty
     assert_eq!(
@@ -154,12 +158,16 @@ async fn test_contentid_get_or_create() -> Result<(), DbErr> {
     // ensure our database is empty
     assert_eq!(contentid::Entity::find().count(&conn).await?, 0);
 
-    let content_id_a = contentid::get_or_create(&content_id_hash, &conn).await;
+    let content_id_a = contentid::get_or_create(&content_id_hash, &conn)
+        .await
+        .unwrap();
 
     // ensure we added a new record to the database.
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);
 
-    let content_id_b = contentid::get_or_create(&content_id_hash, &conn).await;
+    let content_id_b = contentid::get_or_create(&content_id_hash, &conn)
+        .await
+        .unwrap();
 
     // ensure that get_or_create found the existing entry.
     assert_eq!(contentid::Entity::find().count(&conn).await?, 1);

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.68"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 entity = { path = "../entity" }

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use anyhow::Result;
 use clap::Parser;
 use sea_orm::Database;
 use tracing::{debug, info};
@@ -8,7 +9,7 @@ use glados_audit::{cli::Args, run_glados_audit};
 use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     // Setup logging
     env_logger::init();
 
@@ -26,18 +27,17 @@ async fn main() {
     //
     debug!(database_url = &args.database_url, "Connecting to database");
 
-    let conn = Database::connect(&args.database_url)
-        .await
-        .expect("Database connection failed");
+    let conn = Database::connect(&args.database_url).await?;
 
     info!(
         database_url = &args.database_url,
         "database connection established"
     );
 
-    Migrator::up(&conn, None).await.unwrap();
+    Migrator::up(&conn, None).await?;
 
     let ipc_path: PathBuf = args.ipc_path;
 
     run_glados_audit(conn, ipc_path).await;
+    Ok(())
 }

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.68"
 discv5 = "0.1.0"
 ethereum-types = "0.14.0"
 hex = "0.4.3"

--- a/glados-monitor/Cargo.toml
+++ b/glados-monitor/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.68"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 entity = { path = "../entity" }

--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use anyhow::Result;
 use ethportal_api::types::content_key::{
     BlockBodyKey, BlockHeaderKey, BlockReceiptsKey, EpochAccumulatorKey, HistoryContentKey,
     OverlayContentKey,
@@ -11,7 +12,6 @@ use tracing::{debug, error, info, warn};
 use web3::types::{BlockId, H256};
 
 use entity::contentkey;
-use migration::DbErr;
 
 pub mod cli;
 
@@ -142,7 +142,7 @@ async fn store_content_key<'b, T: OverlayContentKey>(
     let encoded: Vec<u8> = key.into();
 
     debug!(
-        content.key=format!("{:x?}", encoded),
+        content.key=format!("encoded{:x?}", encoded),
         content.id=?key.content_id(),
         content.kind=name,
         "Creating content database record",
@@ -162,12 +162,12 @@ async fn store_content_key<'b, T: OverlayContentKey>(
 pub async fn import_pre_merge_accumulators(
     conn: DatabaseConnection,
     base_path: PathBuf,
-) -> Result<(), DbErr> {
+) -> Result<()> {
     info!(base_path = %base_path.as_path().display(), "Starting import of pre-merge accumulators");
 
-    let mut entries = read_dir(base_path).await.unwrap();
+    let mut entries = read_dir(base_path).await?;
 
-    while let Some(entry) = entries.next_entry().await.unwrap() {
+    while let Some(entry) = entries.next_entry().await? {
         let path = entry.path();
 
         debug!(path = path.as_path().to_str(), "Processing path");

--- a/glados-monitor/src/main.rs
+++ b/glados-monitor/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use clap::Parser;
 use sea_orm::{Database, DatabaseConnection};
 use tokio::{signal, task};
@@ -7,10 +8,10 @@ use glados_monitor::{
     cli::{Cli, Commands},
     import_pre_merge_accumulators, run_glados_monitor,
 };
-use migration::{DbErr, Migrator, MigratorTrait};
+use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
-async fn main() -> Result<(), DbErr> {
+async fn main() -> Result<()> {
     // Setup logging
     env_logger::init();
 
@@ -70,11 +71,11 @@ async fn main() -> Result<(), DbErr> {
     Ok(())
 }
 
-async fn do_nothing() -> Result<(), DbErr> {
+async fn do_nothing() -> Result<()> {
     Ok(())
 }
 
-async fn follow_head_command(conn: DatabaseConnection, provider_url: String) -> Result<(), DbErr> {
+async fn follow_head_command(conn: DatabaseConnection, provider_url: String) -> Result<()> {
     //
     // Web3 Connection
     //

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.68"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 entity = { path = "../entity" }

--- a/glados-web/src/main.rs
+++ b/glados-web/src/main.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Result;
 use clap::Parser;
 use sea_orm::Database;
 
@@ -7,18 +8,18 @@ use glados_web::{cli::Args, run_glados_web, state::State};
 use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     // parse command line arguments
     let args = Args::parse();
 
     let conn = Database::connect(args.database_url)
         .await
         .expect("Database connection failed");
-    Migrator::up(&conn, None).await.unwrap();
+    Migrator::up(&conn, None).await?;
 
     let config = Arc::new(State {
         database_connection: conn,
     });
 
-    run_glados_web(config).await;
+    run_glados_web(config).await
 }


### PR DESCRIPTION
### Description

Use `anyhow` for error handling. Predominant benefit is quick and easy handling, especially in the context of
returning multiple error types within a single function. `anyhow` preserves error types, bubbling them up. 

The errors encountered in major code paths (such as loop blocks following the chain tip) are all unpacked and converted to
logs. This should ideally result in very few panics.

### Patterns

These are the rules that I used:

- Import `anyhow::Result` and use that everywhere instead of `std::Result`
- No use of `.unwrap()`, just `?` on the thing and `Result<()>` in signature.
    - Except in `glados-web/src/routes.rs`, axum did not work well with anyhow for some reason at first glance. `unwrap()`s are left there for now.
- Don't put error types in the signature like `Result<(), SpecificError>`. This allows multiple error types in one function.
- Where no value is returned, use 
    - Function signature is `Result<()>`
    - End function with `Ok(())`
- Where a function final expression is a call to another function with a result,
first allow anyhow to deal with the error (`?`), then wrap the success case: (in `Ok()`)
    - Pre `fallible_last_thing().unwrap()`
    - Post `Ok(fallible_last_thing()?)`
- Minimise `.expect("Panic message")`, instead if a message to be included alonside an error, use `anyhow::Context`. This keeps the error message and the new message 
    - `fallible_call().with_context(|| "lazy custom thing, even function calls" )?`    
    - This is useful for file opening errors, where you want to include the path that failed, but also include the actual error kind.
    - `let f = fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?`
    - Note the `||` closure
- Use `bail!()` if there is a need to return with an error and a custom message
    - E.g., `let Some(t) = thing_or_none { else bail!("No thing, returning this error msg")}`
