### PR TITLE
Add support for HeaderWithProof

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The CLI needs a DATABASE_URL to know what relational database to connect to, as 
 > This has only been tested using the `trin` portal network client.
 
 ```
-$ cargo run -p glados-web -- --ipc-path IPC_PATH --database-url DATABASE_URL
+$ cargo run -p glados-web -- --database-url DATABASE_URL
 ```
 
 You should then be able to view the web application at `http://127.0.0.1:3001/` in your browser.

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -79,7 +79,7 @@ pub enum JsonRpcError {
     Empty,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct JsonRPCResult {
     id: u32,
     jsonrpc: String,


### PR DESCRIPTION
The `Header` content type was recently updated to `HeaderWithProof` - and Glados needs to be updated accordingly. Although, technically, the content keys remain (effectively) the same, and it's just the content value that's decoded differently, it seems a good idea to update Glados. I'll mark this pr as ready for review as soon as the next version of `ethportal-api` is released.