### PR TITLE
add welcome message for glados-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
  "axum",
  "clap 4.0.26",
  "entity",
+ "env_logger",
  "ethereum-types 0.14.0",
  "glados-core",
  "hex",
@@ -1733,6 +1734,7 @@ dependencies = [
  "sea-orm",
  "tokio",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -13,11 +13,13 @@ anyhow = "1.0.68"
 glados-core = { path = "../glados-core" }
 migration = { path = "../migration" }
 entity = { path = "../entity" }
+env_logger = "0.9.3"
 askama = "0.11.1"
 axum = "0.6.1"
 sea-orm = "0.10.2"
 ethereum-types = "0.14.0"
 tokio = "1.22.0"
+tracing = "0.1.37"
 clap = { version = "4.0.26", features = ["derive"] }
 tower-http = { version = "0.3.5", features = ["fs"] }
 hex = "0.4.3"

--- a/glados-web/src/main.rs
+++ b/glados-web/src/main.rs
@@ -9,6 +9,7 @@ use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    env_logger::init();
     // parse command line arguments
     let args = Args::parse();
 


### PR DESCRIPTION
### Description

There was no indication of success/failure upon `glados-web` startup

### Changed

Added welcome message `info!()` log:
```sh
...INFO  glados_web] Serving glados-web at <IP>:<Port>
```
Which reads the `SocketAddr` variable.

### Related

- Adds `tracing` and `env_logger` crates