### PR TITLE
Add metadata to glados web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "entity",
  "env_logger",
  "ethereum-types 0.14.0",
+ "ethportal-api",
  "glados-core",
  "hex",
  "migration",

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -10,16 +10,18 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 
 [dependencies]
 anyhow = "1.0.68"
-glados-core = { path = "../glados-core" }
-migration = { path = "../migration" }
-entity = { path = "../entity" }
-env_logger = "0.9.3"
 askama = "0.11.1"
 axum = "0.6.1"
-sea-orm = "0.10.2"
-ethereum-types = "0.14.0"
-tokio = "1.22.0"
-tracing = "0.1.37"
 clap = { version = "4.0.26", features = ["derive"] }
-tower-http = { version = "0.3.5", features = ["fs"] }
+entity = { path = "../entity" }
+env_logger = "0.9.3"
+ethereum-types = "0.14.0"
+ethportal-api = "0.1.3"
+glados-core = { path = "../glados-core" }
 hex = "0.4.3"
+migration = { path = "../migration" }
+sea-orm = "0.10.2"
+tokio = "1.22.0"
+tower-http = { version = "0.3.5", features = ["fs"] }
+tracing = "0.1.37"
+

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -45,7 +45,11 @@ pub struct ContentKeyListTemplate {
 #[derive(Template)]
 #[template(path = "contentkey_detail.html")]
 pub struct ContentKeyDetailTemplate {
-    pub content_key: contentkey::Model,
+    pub content_key_model: contentkey::Model,
+    pub content_key: String,
+    pub content_id: String,
+    pub content_kind: String,
+    pub block_number: Option<i32>,
     pub contentaudit_list: Vec<contentaudit::Model>,
 }
 

--- a/glados-web/templates/contentkey_detail.html
+++ b/glados-web/templates/contentkey_detail.html
@@ -1,16 +1,21 @@
 {% extends "base.html" %}
 
-{% block title %}Content Key: {{ content_key.as_hex() }}{% endblock %}
+{% block title %}Content Key: {{ content_key_model.as_hex() }}{% endblock %}
 
 {% block content %}
   <div class="row">
-    <h1>Content Key: {{ content_key.as_hex() }}</h1>
+    <h1>Content Key: {{ content_key_model.as_hex() }}</h1>
   </div>
   <div class="row">
     <div class="col">
       <ul>
-        <li>Database ID: {{ content_key.id }}</li>
-        <li>Key: {{ content_key.as_hex() }}</li>
+        <li>Database ID: {{ content_key_model.id }}</li>
+        <li>Content Key: {{ content_key }}</li>
+        <li>Content Id: {{ content_id }}</li>
+        <li>Kind: {{ content_kind }}</li>
+        {% if block_number.is_some() %}
+            <li>Block number: {{ block_number.unwrap() }}</li>
+        {% else %}{% endif %}
       </ul>
     </div>
     <div class="col">


### PR DESCRIPTION
### Description

Add information about what a key represents in `glados-web` UI. 

- Fixes #53.

### Depends on

- This PR is rebased on #59 

### Changes
- Uses ethportal-api types in glados-web
- Recreates `HistoryContentKey` from `content_key` bytes that `glados-web` pulls from db.
- Uses `.to_string()` method to display content kind (header, body, receipts, accumulator)
- Performs a lookup of a block number if the content key is not for an accumulator 0x00, 0x01, 0x02.

### Effect

Navigation is unchanged and is as follows:
- Main page (list of content_ids)
    - content_id page (link to content_key)
        - content_key page: (see below)
        
In addition to the audit results, the browser UI now shows:
```
Database ID: 9989
Content Key: 0x0031b4baa7fcd9b087c244eebfbeb8091dac37a44f719df5fc6c848c76ccd6cfdb
Content Id: 0xffe59a4b228fc30120f706fbb8da01a8a217e7439af019ff3268b54ae612f1c6
Kind: BlockHeader { block_hash: 0x31b4..cfdb }
Block number: 16600489
```