### PR TITLE
Use info level logging for glados-monitor record import success message

### DIFF
--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -171,10 +171,10 @@ async fn store_content_key<T: OverlayContentKey>(key: &T, name: &str, conn: &Dat
 fn log_record_outcome<T: OverlayContentKey>(key: &T, name: &str, outcome: DbOutcome) {
     let encoded = hex::encode(key.to_bytes());
     match outcome {
-        DbOutcome::Success => debug!(
+        DbOutcome::Success => info!(
             content.key = format!("0x{encoded}"),
             content.kind = name,
-            "Successful record",
+            "Imported new record",
         ),
         DbOutcome::Fail(e) => error!(
             content.key=format!("0x{encoded}"),


### PR DESCRIPTION
Small adjustment to logging message and level for glados-monitor imports.