### PR TITLE
Remove unique constraint on contentaudit's contentkey column

### DIFF
--- a/entity/src/contentaudit.rs
+++ b/entity/src/contentaudit.rs
@@ -20,7 +20,7 @@ pub enum AuditResult {
 pub struct Model {
     #[sea_orm(primary_key, indexed)]
     pub id: i32,
-    #[sea_orm(unique, indexed)]
+    #[sea_orm(indexed)]
     pub content_key: i32,
     pub created_at: DateTime<Utc>,
     pub result: AuditResult,


### PR DESCRIPTION
The `content_audit` model mistakenly had a `unique` constraint on its `content_key` column, which will lead to errors when trying to re-audit a particular content key. 