### PR TITLE
add tables to dashboard for granular audit overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "anyhow",
  "askama",
  "axum",
+ "chrono",
  "clap 4.0.26",
  "entity",
  "env_logger",

--- a/entity/src/content.rs
+++ b/entity/src/content.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use chrono::{DateTime, FixedOffset, Utc};
 use ethereum_types::H256;
-use ethportal_api::types::content_key::OverlayContentKey;
+use ethportal_api::types::content_key::{hex_encode_compact, OverlayContentKey};
 use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 
 /// Portal network sub-protocol. History, state, transactions etc.
@@ -11,6 +11,15 @@ use sea_orm::{entity::prelude::*, ActiveValue::NotSet, Set};
 pub enum SubProtocol {
     History = 0,
     State = 1,
+}
+
+impl SubProtocol {
+    pub fn as_text(&self) -> String {
+        match self {
+            SubProtocol::History => "History".to_string(),
+            SubProtocol::State => "State".to_string(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
@@ -95,8 +104,26 @@ impl Model {
         format!("0x{hex}")
     }
 
+    pub fn id_as_hex_short(&self) -> String {
+        hex_encode_compact(&self.content_id)
+    }
+
+    pub fn key_as_hash(&self) -> H256 {
+        H256::from_slice(&self.content_key)
+    }
+
     pub fn key_as_hex(&self) -> String {
         let hex = hex::encode(&self.content_key);
         format!("0x{hex}")
+    }
+
+    pub fn key_as_hex_short(&self) -> String {
+        hex_encode_compact(&self.content_key)
+    }
+
+    pub fn available_at_local_time(&self) -> String {
+        self.first_available_at
+            .with_timezone(&chrono::Local)
+            .to_rfc2822()
     }
 }

--- a/entity/src/content_audit.rs
+++ b/entity/src/content_audit.rs
@@ -13,6 +13,15 @@ pub enum AuditResult {
     Success = 1,
 }
 
+impl AuditResult {
+    pub fn as_text(&self) -> String {
+        match self {
+            AuditResult::Failure => "fail".to_string(),
+            AuditResult::Success => "success".to_string(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "content_audit")]
 pub struct Model {
@@ -81,5 +90,8 @@ pub async fn get_audits<T: OverlayContentKey>(
 impl Model {
     pub fn is_success(&self) -> bool {
         self.result == AuditResult::Success
+    }
+    pub fn created_at_local_time(&self) -> String {
+        self.created_at.with_timezone(&chrono::Local).to_rfc2822()
     }
 }

--- a/glados-web/Cargo.toml
+++ b/glados-web/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Piper Merriam <piper@pipermerriam.com>"]
 anyhow = "1.0.68"
 askama = "0.11.1"
 axum = "0.6.1"
+chrono = "0.4.23"
 clap = { version = "4.0.26", features = ["derive"] }
 entity = { path = "../entity" }
 env_logger = "0.9.3"

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -47,30 +47,101 @@ pub async fn node_list(Extension(state): Extension<Arc<State>>) -> impl IntoResp
 
 pub async fn content_dashboard(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let contentid_list = content::Entity::find()
-        .order_by_desc(content::Column::ContentId)
-        .limit(10)
+        .order_by_desc(content::Column::FirstAvailableAt)
+        .limit(20)
         .all(&state.database_connection)
         .await
         .unwrap();
-    let contentaudit_list = content_audit::Entity::find()
-        .order_by_desc(content_audit::Column::CreatedAt)
-        .limit(10)
-        .all(&state.database_connection)
-        .await
-        .unwrap();
-    let contentaudit_pass_list = content_audit::Entity::find()
-        .filter(content_audit::Column::Result.eq(AuditResult::Success))
-        .order_by_desc(content_audit::Column::CreatedAt)
-        .limit(10)
-        .all(&state.database_connection)
-        .await
-        .unwrap();
+
+    let recent_content_model: Vec<(content::Model, Vec<content_audit::Model>)> =
+        content::Entity::find()
+            .order_by_desc(content::Column::FirstAvailableAt)
+            .find_with_related(content_audit::Entity)
+            .filter(content_audit::Column::Result.is_not_null())
+            .limit(20)
+            .all(&state.database_connection)
+            .await
+            .unwrap();
+
+    let recent_audits_model: Vec<(content_audit::Model, Vec<content::Model>)> =
+        content_audit::Entity::find()
+            .order_by_desc(content_audit::Column::CreatedAt)
+            .find_with_related(content::Entity)
+            .limit(20)
+            .all(&state.database_connection)
+            .await
+            .unwrap();
+
+    let recent_audit_success_model: Vec<(content_audit::Model, Vec<content::Model>)> =
+        content_audit::Entity::find()
+            .order_by_desc(content_audit::Column::CreatedAt)
+            .find_with_related(content::Entity)
+            .filter(content_audit::Column::Result.eq(AuditResult::Success))
+            .limit(20)
+            .all(&state.database_connection)
+            .await
+            .unwrap();
+
+    let recent_audit_failure_model: Vec<(content_audit::Model, Vec<content::Model>)> =
+        content_audit::Entity::find()
+            .order_by_desc(content_audit::Column::CreatedAt)
+            .find_with_related(content::Entity)
+            .filter(content_audit::Column::Result.eq(AuditResult::Failure))
+            .limit(20)
+            .all(&state.database_connection)
+            .await
+            .unwrap();
+
     let template = ContentDashboardTemplate {
         contentid_list,
-        contentaudit_list,
-        contentaudit_pass_list,
+        recent_content: content_model_to_display(recent_content_model),
+        recent_audits: audit_model_to_display(recent_audits_model),
+        recent_audit_successes: audit_model_to_display(recent_audit_success_model),
+        recent_audit_failures: audit_model_to_display(recent_audit_failure_model),
     };
     HtmlTemplate(template)
+}
+
+/// Summary of a model result (content with vector of audits).
+fn content_model_to_display(
+    content_model: Vec<(content::Model, Vec<content_audit::Model>)>,
+) -> Vec<(content::Model, content_audit::Model)> {
+    content_model
+        .into_iter()
+        .map(|content| {
+            let content_data = content.0;
+            let mut audits = content.1;
+            audits.sort_by(|a, b| a.id.cmp(&b.id));
+            let latest_audit = audits
+                .into_iter()
+                // Choose the latest audit.
+                .rev()
+                .next()
+                // We know there will beat least one audit because we filtered nulls out after joining.
+                .expect("Tables should be filtered to exclude Null values.");
+
+            (content_data, latest_audit)
+        })
+        .collect()
+}
+
+/// Summary of a model result (audit with vector of content).
+fn audit_model_to_display(
+    content_model: Vec<(content_audit::Model, Vec<content::Model>)>,
+) -> Vec<(content::Model, content_audit::Model)> {
+    content_model
+        .into_iter()
+        .map(|content| {
+            let audit = content.0;
+            let content_data = content.1;
+            let content_data: entity::content::Model = content_data
+                .into_iter()
+                .next()
+                // We know there will be one content because audits only have one one content foreign key.
+                .expect("Tables should be filtered to exclude Null values.");
+            (content_data, audit)
+        })
+        .collect()
 }
 
 pub async fn contentid_list(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -20,8 +20,10 @@ pub struct NodeListTemplate {
 #[template(path = "content_dashboard.html")]
 pub struct ContentDashboardTemplate {
     pub contentid_list: Vec<content::Model>,
-    pub contentaudit_list: Vec<content_audit::Model>,
-    pub contentaudit_pass_list: Vec<content_audit::Model>,
+    pub recent_content: Vec<(content::Model, content_audit::Model)>,
+    pub recent_audits: Vec<(content::Model, content_audit::Model)>,
+    pub recent_audit_successes: Vec<(content::Model, content_audit::Model)>,
+    pub recent_audit_failures: Vec<(content::Model, content_audit::Model)>,
 }
 
 #[derive(Template)]

--- a/glados-web/templates/content_dashboard.html
+++ b/glados-web/templates/content_dashboard.html
@@ -3,40 +3,144 @@
 {% block title %}Content Dashboard{% endblock %}
 
 {% block content %}
-  <div class="row">
-    <h1>Content Dashboard</h1>
-  </div>
-  <div class="row">
+<div class="row">
     <div class="col">
-      <h2>Recent Content</h2>
-      <ul>
-        {% for content in contentid_list %}
-          <li><a href="/content/id/{{content.id_as_hex() }}">{{ content.id_as_hash() }}</a></li>
-        {% else %}
-          <li>No content found</li>
-        {% endfor %}
-      </ul>
-    </div>
-    <div class="col">
-      <h2>Recent Audits</h2>
-      <ul>
-        {% for contentaudit in contentaudit_list %}
-        <li>Audit#={{ contentaudit.content_key }} <span class="badge text-bg-{% if contentaudit.is_success() %}success{% else %}danger{% endif %}">{% if contentaudit.is_success() %}Success{% else %}Fail{% endif %}</span></li>
-        {% else %}
-          <li>No audits found</li>
-        {% endfor %}
-      </ul>
-    </div>
-    <div class="row">
-        <h2>Successful audits</h2>
         <ul>
-          {% for contentaudit in contentaudit_pass_list %}
-          <li>Audit#={{ contentaudit.content_key }} <span class="badge text-bg-{% if contentaudit.is_success() %}success{% else %}danger{% endif %}">{% if contentaudit.is_success() %}Success{% else %}Fail{% endif %}</span></li>
-          {% else %}
-            <li>No successful audits found</li>
-          {% endfor %}
+            <h1>Content Dashboard</h1>
+            <div>Audit stats: TODO</div>
         </ul>
-      </div>
-  </div>
+
+    </div>
+</div>
+<div class="row">
+    <div class="col">
+        <ul>
+            <h2> Recent content with audits</h2>
+            <table>
+                <tr>
+                    <td>|  Result </td>
+                    <td>|  Sub-protocol </td>
+                    <td>|  Content Key</td>
+                    <td>|  Content ID</td>
+                    <td>|  Content first available</td>
+                    <td>|  Audited at</td>
+                </tr>
+                {% for (content, audit) in recent_content %}
+                <tr>
+                    <td>|  <span class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{% if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                    <td>|  {{ content.protocol_id.as_text() }} </td>
+                    <td>|  <a href="/content/key/{{content.key_as_hex()}}">{{ content.key_as_hex_short() }}</a></td>
+                    <td>|  <a href="/content/id/{{content.id_as_hex()}}">{{  content.id_as_hex_short() }}</a></td>
+                    <td>|  {{ content.available_at_local_time() }}</td>
+                    <td>|  {{ audit.created_at_local_time() }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </ul>
+    </div>
+</div>
+<div class="row">
+    <div class="col">
+        <ul>
+        <h2>Recent Content</h2>
+        <table>
+            <tr>
+                <td>|  Sub-protocol </td>
+                <td>|  Content Key</td>
+                <td>|  Content ID</td>
+                <td>|  Content first available</td>
+            </tr>
+            {% for content in contentid_list %}
+            <tr>
+                <td>|  {{ content.protocol_id.as_text() }} </td>
+                <td>|  <a href="/content/id/{{content.id_as_hex() }}">{{ content.id_as_hex_short() }}</a></td>
+                <td>|  <a href="/content/key/{{content.key_as_hex() }}">{{ content.key_as_hex_short() }}</a></td>
+                <td>|  {{ content.available_at_local_time() }}</td>
+            </tr>
+            {% endfor %}
+            </table>
+        </ul>
+    </div>
+</div>
+<div class="row">
+    <div class="col">
+        <ul>
+            <h2> Recent audits</h2>
+            <table>
+                <tr>
+                    <td>|  Result </td>
+                    <td>|  Sub-protocol </td>
+                    <td>|  Content Key</td>
+                    <td>|  Content ID</td>
+                    <td>|  Content first available</td>
+                    <td>|  Audited at</td>
+                </tr>
+                {% for (content, audit) in recent_audits %}
+                <tr>
+                    <td>|  <span class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{% if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                    <td>|  {{ content.protocol_id.as_text() }} </td>
+                    <td>|  <a href="/content/key/{{content.key_as_hex()}}">{{ content.key_as_hex_short() }}</a></td>
+                    <td>|  <a href="/content/id/{{content.id_as_hex()}}">{{  content.id_as_hex_short() }}</a></td>
+                    <td>|  {{ content.available_at_local_time() }}</td>
+                    <td>|  {{ audit.created_at_local_time() }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </ul>
+    </div>
+</div>
+<div class="row">
+    <div class="col">
+        <ul>
+            <h2> Recent audit successes</h2>
+            <table>
+                <tr>
+                    <td>|  Result </td>
+                    <td>|  Sub-protocol </td>
+                    <td>|  Content Key</td>
+                    <td>|  Content ID</td>
+                    <td>|  Content first available</td>
+                    <td>|  Audited at</td>
+                </tr>
+                {% for (content, audit) in recent_audit_successes %}
+                <tr>
+                    <td>|  <span class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{% if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                    <td>|  {{ content.protocol_id.as_text() }} </td>
+                    <td>|  <a href="/content/key/{{content.key_as_hex()}}">{{ content.key_as_hex_short() }}</a></td>
+                    <td>|  <a href="/content/id/{{content.id_as_hex()}}">{{  content.id_as_hex_short() }}</a></td>
+                    <td>|  {{ content.available_at_local_time() }}</td>
+                    <td>|  {{ audit.created_at_local_time() }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </ul>
+    </div>
+</div>
+<div class="row">
+    <div class="col">
+        <ul>
+            <h2> Recent audit failures</h2>
+            <table>
+                <tr>
+                    <td>|  Result </td>
+                    <td>|  Sub-protocol </td>
+                    <td>|  Content Key</td>
+                    <td>|  Content ID</td>
+                    <td>|  Content first available</td>
+                    <td>|  Audited at</td>
+                </tr>
+                {% for (content, audit) in recent_audit_failures %}
+                <tr>
+                    <td>|  <span class="badge text-bg-{% if audit.is_success() %}success{% else %}danger{% endif %}">{% if audit.is_success() %}Success{% else %}Fail{% endif %}</span></td>
+                    <td>|  {{ content.protocol_id.as_text() }} </td>
+                    <td>|  <a href="/content/key/{{content.key_as_hex()}}">{{ content.key_as_hex_short() }}</a></td>
+                    <td>|  <a href="/content/id/{{content.id_as_hex()}}">{{  content.id_as_hex_short() }}</a></td>
+                    <td>|  {{ content.available_at_local_time() }}</td>
+                    <td>|  {{ audit.created_at_local_time() }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </ul>
+    </div>
 </div>
 {% endblock %}

--- a/glados-web/templates/contentid_detail.html
+++ b/glados-web/templates/contentid_detail.html
@@ -11,7 +11,6 @@
       <ul>
         <li>Database ID: {{ content_id.id }}</li>
         <li>ID: {{ content_id.id_as_hex() }}</li>
-        <li>Last audited: TODO</li>
       </ul>
     </div>
     <div class="col">


### PR DESCRIPTION
### Description

Adds content to the glados-web dashboard. Partially resolves the following issue:
- #72

### Details
Tables have (where appropriate) columns:
- Result
- Sub-protocol
- Content key
- Content ID
- Content available at
- Audited at

Includes sections with each with a table containing 20 rows:
- Recent content with audits
- Recent content (no audit data in this table)
- Recent audits
- Recent audit successes
- Recent audit failures

### Comment
A todo is left at the top of the page for audit statistics to be added in a different PR