### PR TITLE
add error handling to glados-web

### DIFF
--- a/glados-web/src/lib.rs
+++ b/glados-web/src/lib.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::{net::SocketAddr, path::Path};
 
 use anyhow::{bail, Result};
+use axum::http::StatusCode;
 use axum::{
     extract::Extension,
     routing::{get, get_service},
@@ -42,9 +43,17 @@ pub async fn run_glados_web(config: Arc<State>) -> Result<()> {
         .fallback_service(serve_dir)
         .layer(Extension(config));
 
+    let app = app.fallback(handler_404);
+
     let socket: SocketAddr = SOCKET.parse()?;
     info!("Serving glados-web at {}", socket);
     Ok(axum::Server::bind(&socket)
         .serve(app.into_make_service())
         .await?)
+}
+
+/// Global routing error handler to prevent panics.
+async fn handler_404() -> StatusCode {
+    tracing::error!("404: Non-existent page visited");
+    StatusCode::NOT_FOUND
 }

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -14,6 +14,7 @@ use entity::{
     content_audit::{self, AuditResult},
     execution_metadata, node,
 };
+use tracing::error;
 
 use crate::state::State;
 use crate::templates::{
@@ -34,93 +35,122 @@ pub async fn root(Extension(_state): Extension<Arc<State>>) -> impl IntoResponse
     HtmlTemplate(template)
 }
 
-pub async fn node_list(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
+pub async fn node_list(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<HtmlTemplate<NodeListTemplate>, StatusCode> {
+    const KEY_COUNT: u64 = 50;
     let nodes: Vec<node::Model> = node::Entity::find()
         .order_by_asc(node::Column::NodeId)
-        .limit(50)
+        .limit(KEY_COUNT)
         .all(&state.database_connection)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(key.count=KEY_COUNT, err=?e, "Could not look up database node ids");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     let template = NodeListTemplate { nodes };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }
 
-pub async fn content_dashboard(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
+pub async fn content_dashboard(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<HtmlTemplate<ContentDashboardTemplate>, StatusCode> {
+    const KEY_COUNT: u64 = 20;
     let contentid_list = content::Entity::find()
         .order_by_desc(content::Column::FirstAvailableAt)
-        .limit(20)
+        .limit(KEY_COUNT)
         .all(&state.database_connection)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(key.count=KEY_COUNT, err=?e, "Could not look up latest keys");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let recent_content_model: Vec<(content::Model, Vec<content_audit::Model>)> =
         content::Entity::find()
             .order_by_desc(content::Column::FirstAvailableAt)
             .find_with_related(content_audit::Entity)
             .filter(content_audit::Column::Result.is_not_null())
-            .limit(20)
+            .limit(KEY_COUNT)
             .all(&state.database_connection)
             .await
-            .unwrap();
+            .map_err(|e| {
+                error!(key.count=KEY_COUNT, err=?e, "Could not look up latest keys with audits");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
     let recent_audits_model: Vec<(content_audit::Model, Vec<content::Model>)> =
         content_audit::Entity::find()
             .order_by_desc(content_audit::Column::CreatedAt)
             .find_with_related(content::Entity)
-            .limit(20)
+            .limit(KEY_COUNT)
             .all(&state.database_connection)
             .await
-            .unwrap();
+            .map_err(|e| {
+                error!(key.count=KEY_COUNT, err=?e, "Could not look up recent audits");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
     let recent_audit_success_model: Vec<(content_audit::Model, Vec<content::Model>)> =
         content_audit::Entity::find()
             .order_by_desc(content_audit::Column::CreatedAt)
             .find_with_related(content::Entity)
             .filter(content_audit::Column::Result.eq(AuditResult::Success))
-            .limit(20)
+            .limit(KEY_COUNT)
             .all(&state.database_connection)
             .await
-            .unwrap();
+            .map_err(|e| {
+                error!(key.count=KEY_COUNT, err=?e, "Could not look up recent successful audits");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
     let recent_audit_failure_model: Vec<(content_audit::Model, Vec<content::Model>)> =
         content_audit::Entity::find()
             .order_by_desc(content_audit::Column::CreatedAt)
             .find_with_related(content::Entity)
             .filter(content_audit::Column::Result.eq(AuditResult::Failure))
-            .limit(20)
+            .limit(KEY_COUNT)
             .all(&state.database_connection)
             .await
-            .unwrap();
+            .map_err(|e| {
+                error!(key.count=KEY_COUNT, err=?e, "Could not look up recent failed audits");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
     let template = ContentDashboardTemplate {
         contentid_list,
-        recent_content: content_model_to_display(recent_content_model),
-        recent_audits: audit_model_to_display(recent_audits_model),
-        recent_audit_successes: audit_model_to_display(recent_audit_success_model),
-        recent_audit_failures: audit_model_to_display(recent_audit_failure_model),
+        recent_content: content_model_to_display(recent_content_model)?,
+        recent_audits: audit_model_to_display(recent_audits_model)?,
+        recent_audit_successes: audit_model_to_display(recent_audit_success_model)?,
+        recent_audit_failures: audit_model_to_display(recent_audit_failure_model)?,
     };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }
 
 /// Summary of a model result (content with vector of audits).
 fn content_model_to_display(
     content_model: Vec<(content::Model, Vec<content_audit::Model>)>,
-) -> Vec<(content::Model, content_audit::Model)> {
+) -> Result<Vec<(content::Model, content_audit::Model)>, StatusCode> {
     content_model
         .into_iter()
         .map(|content| {
             let content_data = content.0;
             let mut audits = content.1;
             audits.sort_by(|a, b| a.id.cmp(&b.id));
-            let latest_audit = audits
+            let latest_audit: Result<entity::content_audit::Model, StatusCode> = audits
                 .into_iter()
                 // Choose the latest audit.
                 .rev()
                 .next()
                 // We know there will beat least one audit because we filtered nulls out after joining.
-                .expect("Tables should be filtered to exclude Null values.");
-
-            (content_data, latest_audit)
+                .ok_or({
+                    error!("Expected content to have at least one associated audit.");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                });
+            match latest_audit {
+                Ok(a) => Ok((content_data, a)),
+                Err(e) => Err(e),
+            }
         })
         .collect()
 }
@@ -128,67 +158,97 @@ fn content_model_to_display(
 /// Summary of a model result (audit with vector of content).
 fn audit_model_to_display(
     content_model: Vec<(content_audit::Model, Vec<content::Model>)>,
-) -> Vec<(content::Model, content_audit::Model)> {
+) -> Result<Vec<(content::Model, content_audit::Model)>, StatusCode> {
     content_model
         .into_iter()
         .map(|content| {
             let audit = content.0;
             let content_data = content.1;
-            let content_data: entity::content::Model = content_data
+            let content_data: Result<entity::content::Model, StatusCode> = content_data
                 .into_iter()
                 .next()
                 // We know there will be one content because audits only have one one content foreign key.
-                .expect("Tables should be filtered to exclude Null values.");
-            (content_data, audit)
+                .ok_or({
+                    error!("Expected audit to have at least one associated content.");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                });
+            match content_data {
+                Ok(c) => Ok((c, audit)),
+                Err(e) => Err(e),
+            }
         })
         .collect()
 }
 
-pub async fn contentid_list(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
+pub async fn contentid_list(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<HtmlTemplate<ContentIdListTemplate>, StatusCode> {
+    const KEY_COUNT: u64 = 50;
     let contentid_list: Vec<content::Model> = content::Entity::find()
         .order_by_asc(content::Column::ContentId)
-        .limit(50)
+        .limit(KEY_COUNT)
         .all(&state.database_connection)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(key.count=KEY_COUNT, err=?e, "Could not look up ids");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     let template = ContentIdListTemplate { contentid_list };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }
 
 pub async fn contentid_detail(
     Path(content_id_hex): Path<String>,
     Extension(state): Extension<Arc<State>>,
-) -> impl IntoResponse {
-    let content_id_raw = hex::decode(&content_id_hex[2..]).unwrap();
+) -> Result<HtmlTemplate<ContentIdDetailTemplate>, StatusCode> {
+    let content_id_raw = hex::decode(&content_id_hex[2..]).map_err(|e| {
+        error!(content.id=content_id_hex, err=?e, "Could not decode up id bytes");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     let content_id = content::Entity::find()
         .filter(content::Column::ContentId.eq(content_id_raw.clone()))
         .one(&state.database_connection)
         .await
-        .unwrap()
-        .expect("No content found");
+        .map_err(|e| {
+            error!(content.id=content_id_hex, err=?e, "Could not look up id");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or({
+            error!(content.id = content_id_hex, "No data for id");
+            StatusCode::NOT_FOUND
+        })?;
 
     let contentkey_list = content::Entity::find()
         .filter(content::Column::ContentId.eq(content_id_raw))
         .all(&state.database_connection)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(content.id=content_id_hex, err=?e, "Could not content keys for id");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let template = ContentIdDetailTemplate {
         content_id,
         contentkey_list,
     };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }
 
-pub async fn contentkey_list(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
+pub async fn contentkey_list(
+    Extension(state): Extension<Arc<State>>,
+) -> Result<HtmlTemplate<ContentKeyListTemplate>, StatusCode> {
+    const KEY_COUNT: u64 = 50;
     let contentkey_list: Vec<content::Model> = content::Entity::find()
         .order_by_desc(content::Column::Id)
-        .limit(50)
+        .limit(KEY_COUNT)
         .all(&state.database_connection)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(key.count=KEY_COUNT, err=?e, "Could not look up keys");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     let template = ContentKeyListTemplate { contentkey_list };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }
 
 /// Retrieves key details to display.
@@ -197,28 +257,46 @@ pub async fn contentkey_list(Extension(state): Extension<Arc<State>>) -> impl In
 pub async fn contentkey_detail(
     Path(content_key_hex): Path<String>,
     Extension(state): Extension<Arc<State>>,
-) -> impl IntoResponse {
-    let content_key_raw = hex::decode(&content_key_hex[2..]).unwrap();
+) -> Result<HtmlTemplate<ContentKeyDetailTemplate>, StatusCode> {
+    let content_key_raw = hex::decode(&content_key_hex[2..]).map_err(|e| {
+        error!(content.key=content_key_hex, err=?e, "Could not decode up key bytes");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     let content_key_model = content::Entity::find()
         .filter(content::Column::ContentKey.eq(content_key_raw.clone()))
         .one(&state.database_connection)
         .await
-        .unwrap()
-        .expect("No content found");
+        .map_err(|e| {
+            error!(content.key=content_key_hex, err=?e, "Could not look up key");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or({
+            error!(content.key = content_key_hex, "No data for key");
+            StatusCode::NOT_FOUND
+        })?;
 
     let contentaudit_list = content_key_model
         .find_related(content_audit::Entity)
         .all(&state.database_connection)
         .await
-        .expect("Could not look up audits.");
+        .map_err(|e| {
+            error!(content.key=content_key_hex, err=?e, "Could not look up audits for key");
+            StatusCode::NOT_FOUND
+        })?;
 
     let content_key: HistoryContentKey = HistoryContentKey::try_from(content_key_raw.clone())
-        .expect("Could not convert key bytes into OverlayContentKey.");
+        .map_err(|e| {
+            error!(content.key=content_key_hex, err=?e, "Could not create key from bytes.");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     let metadata_model = execution_metadata::Entity::find()
         .filter(execution_metadata::Column::Content.eq(content_key_model.id))
         .one(&state.database_connection)
         .await
-        .expect("No content found");
+        .map_err(|e| {
+            error!(content.key=content_key_hex, err=?e, "No content metadata found");
+            StatusCode::NOT_FOUND
+        })?;
     let block_number = metadata_model.map(|m| m.block_number);
 
     let content_id = format!("0x{}", hex::encode(content_key.content_id()));
@@ -231,5 +309,5 @@ pub async fn contentkey_detail(
         content_kind,
         block_number,
     };
-    HtmlTemplate(template)
+    Ok(HtmlTemplate(template))
 }

--- a/glados-web/src/templates.rs
+++ b/glados-web/src/templates.rs
@@ -56,7 +56,7 @@ pub struct ContentKeyDetailTemplate {
     pub contentaudit_list: Vec<content_audit::Model>,
 }
 
-pub struct HtmlTemplate<T>(pub T);
+pub struct HtmlTemplate<T: Template>(pub T);
 
 impl<T> IntoResponse for HtmlTemplate<T>
 where


### PR DESCRIPTION
### Issue addressed

- Closes #64 

### Proposed changes

Handle errors in `glados-web` by logging and routing with HTTP response codes
- Removed unwrap() and expect() usage
- Entering incorrect routes is handled with response codes