### PR TITLE
Add concurrency to audits

### DIFF
--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -1,11 +1,43 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-#[derive(Parser, Debug)]
+const DEFAULT_DB_URL: &str = "sqlite::memory:";
+
+#[derive(Clone, Debug, Eq, Parser, PartialEq)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long, default_value = "sqlite::memory:")]
+    #[arg(short, long, default_value = DEFAULT_DB_URL)]
     pub database_url: String,
     #[arg(short, long)]
     pub ipc_path: PathBuf,
+    #[arg(short, long, default_value = "4", help = "number of auditing threads")]
+    pub concurrency: u8,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_minimum_args() {
+        const IPC_PATH: &str = "/path/to/ipc";
+        let result = Args::parse_from(["test", "--ipc-path", IPC_PATH]);
+        let expected = Args {
+            database_url: DEFAULT_DB_URL.to_string(),
+            ipc_path: PathBuf::from(IPC_PATH),
+            concurrency: 4,
+        };
+        assert_eq!(result, expected);
+    }
+    #[test]
+    fn test_custom_concurrency() {
+        const IPC_PATH: &str = "/path/to/ipc";
+        let result = Args::parse_from(["test", "--ipc-path", IPC_PATH, "--concurrency", "3"]);
+        let expected = Args {
+            database_url: DEFAULT_DB_URL.to_string(),
+            ipc_path: PathBuf::from(IPC_PATH),
+            concurrency: 3,
+        };
+        assert_eq!(result, expected);
+    }
 }

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -104,7 +104,7 @@ async fn perform_content_audits(
 
 /// Performs an audit against a Portal node.
 ///
-/// After auditing finishes the thread counter is deprecated. This
+/// After auditing finishes the thread counter is decremented. This
 /// applies even if the audit process encounters an error.
 async fn perform_single_audit(
     active_threads: Arc<AtomicU8>,

--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -1,9 +1,17 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+};
 
-use anyhow::Result;
 use ethportal_api::{types::content_key::OverlayContentKey, HistoryContentKey};
 use sea_orm::DatabaseConnection;
-use tokio::sync::mpsc;
+use tokio::{
+    sync::mpsc,
+    time::{sleep, Duration},
+};
 use tracing::{debug, error, info};
 
 use entity::{
@@ -24,7 +32,8 @@ pub struct AuditTask {
     pub content_key: HistoryContentKey,
 }
 
-pub async fn run_glados_audit(conn: DatabaseConnection, ipc_path: PathBuf) {
+pub async fn run_glados_audit(conn: DatabaseConnection, ipc_path: PathBuf, max_concurrency: u8) {
+    info!(max.concurrency = max_concurrency, "starting glados audit.");
     let (tx, rx) = mpsc::channel::<AuditTask>(100);
     let strategies = vec![
         SelectionStrategy::Latest,
@@ -39,7 +48,9 @@ pub async fn run_glados_audit(conn: DatabaseConnection, ipc_path: PathBuf) {
             conn.clone(),
         ));
     }
-    tokio::spawn(perform_content_audits(rx, ipc_path.clone(), conn.clone()));
+
+    tokio::spawn(perform_content_audits(max_concurrency, rx, ipc_path, conn));
+
     debug!("setting up CTRL+C listener");
     tokio::signal::ctrl_c()
         .await
@@ -48,62 +59,141 @@ pub async fn run_glados_audit(conn: DatabaseConnection, ipc_path: PathBuf) {
     info!("got CTRL+C. shutting down...");
 }
 
-/// Receives content audit tasks created according to some strategy.
 async fn perform_content_audits(
+    max_concurrency: u8,
     mut rx: mpsc::Receiver<AuditTask>,
     ipc_path: PathBuf,
     conn: DatabaseConnection,
-) -> Result<()> {
-    let mut client = PortalClient::from_ipc(&ipc_path).expect("Could not connect to portal node.");
+) {
+    let active_threads = Arc::new(AtomicU8::new(0));
+    loop {
+        let active_count = active_threads.load(Ordering::Relaxed);
+        if active_count >= max_concurrency {
+            // Each audit is performed in new thread if enough concurrency is available.
+            debug!(
+                active.threads = active_count,
+                max.threads = max_concurrency,
+                "Max concurrency reached. Sleeping..."
+            );
+            sleep(Duration::from_millis(1000)).await;
+            continue;
+        }
 
-    while let Some(task) = rx.recv().await {
-        debug!(content.key = task.content_key.to_hex(), "auditing content",);
-        let content = client.get_content(&task.content_key)?;
+        debug!(
+            active.threads = active_count,
+            max.threads = max_concurrency,
+            "Checking Rx channel for audits"
+        );
 
-        let raw_data = content.raw;
-        let audit_result = raw_data.len() > 2;
-        let content_key_model = match content::get(&task.content_key, &conn).await {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                error!(
-                    content.key=?task.content_key,
-                    audit.pass=?audit_result,
-                    "Content_key not found in db."
-                );
+        match rx.recv().await {
+            Some(task) => {
+                active_threads.fetch_add(1, Ordering::Relaxed);
+                tokio::spawn(perform_single_audit(
+                    active_threads.clone(),
+                    task,
+                    ipc_path.clone(),
+                    conn.clone(),
+                ))
+            }
+            None => {
                 continue;
             }
-            Err(e) => {
-                error!(
-                    content.key=?task.content_key,
-                    err=?e,
-                    "Could not look up content_key in db."
-                );
-                continue;
-            }
-        };
-        content_audit::create(content_key_model.id, audit_result, task.strategy, &conn).await?;
-
-        // Display audit result with block metadata.
-        match execution_metadata::get(content_key_model.id, &conn).await {
-            Ok(Some(b)) => {
-                info!(
-                    content.key=task.content_key.to_hex(),
-                    audit.pass=?audit_result,
-                    block = b.block_number,
-                );
-            }
-            Ok(None) => {
-                error!(
-                    content.key=task.content_key.to_hex(),
-                    audit.pass=?audit_result,
-                    "Block metadata absent for key."
-                );
-            }
-            Err(e) => error!(
-                    content.key=task.content_key.to_hex(),
-                    err=?e,
-                    "Problem getting block metadata."),
         };
     }
-    Ok(())
+}
+
+/// Performs an audit against a Portal node.
+///
+/// After auditing finishes the thread counter is deprecated. This
+/// applies even if the audit process encounters an error.
+async fn perform_single_audit(
+    active_threads: Arc<AtomicU8>,
+    task: AuditTask,
+    ipc_path: PathBuf,
+    conn: DatabaseConnection,
+) {
+    let mut client = match PortalClient::from_ipc(&ipc_path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                content.key=?task.content_key,
+                err=?e,
+                "Could not connect to Portal node."
+            );
+            active_threads.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    debug!(content.key = task.content_key.to_hex(), "auditing content",);
+    let content = match client.get_content(&task.content_key) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(
+                content.key=?task.content_key,
+                err=?e,
+                "Could not get content from Portal node."
+            );
+            active_threads.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    let raw_data = content.raw;
+    let audit_result = raw_data.len() > 2;
+    let content_key_model = match content::get(&task.content_key, &conn).await {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            error!(
+                content.key=?task.content_key,
+                audit.pass=?audit_result,
+                "Content key not found in db."
+            );
+            active_threads.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+        Err(e) => {
+            error!(
+                content.key=?task.content_key,
+                err=?e,
+                "Could not look up content key in db."
+            );
+            active_threads.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+    };
+    if let Err(e) =
+        content_audit::create(content_key_model.id, audit_result, task.strategy, &conn).await
+    {
+        error!(
+            content.key=?task.content_key,
+            err=?e,
+            "Could not create audit entry in db."
+        );
+        active_threads.fetch_sub(1, Ordering::Relaxed);
+        return;
+    };
+
+    // Display audit result with block metadata.
+    match execution_metadata::get(content_key_model.id, &conn).await {
+        Ok(Some(b)) => {
+            info!(
+                content.key=task.content_key.to_hex(),
+                audit.pass=?audit_result,
+                block = b.block_number,
+            );
+        }
+        Ok(None) => {
+            error!(
+                content.key=task.content_key.to_hex(),
+                audit.pass=?audit_result,
+                "Block metadata absent for key."
+            );
+        }
+        Err(e) => error!(
+                content.key=task.content_key.to_hex(),
+                err=?e,
+                "Problem getting block metadata."),
+    };
+    active_threads.fetch_sub(1, Ordering::Relaxed);
 }

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -38,6 +38,6 @@ async fn main() -> Result<()> {
 
     let ipc_path: PathBuf = args.ipc_path;
 
-    run_glados_audit(conn, ipc_path).await;
+    run_glados_audit(conn, ipc_path, args.concurrency).await;
     Ok(())
 }


### PR DESCRIPTION
### Issue addressed

- Fixes #67 

### Proposed changes

A CLI flag `--concurrency <n>` controls the number of threads that look at the Rx side of the channel and call Portal nodes for the content (ie perform the audit).

### Description 

- The receiver of the multi-producer, single-receiver channel spawns threads as tasks arrive in the channel. 
- An atomic integer (`Arc<AtomicU8>`) keeps track of the number of active threads.
- **+1** Spawned tasks cause an **increment** of the atomic integer.
- **-1** Threads that either complete an audit or otherwise log an error and terminate cause a **decrement** the atomic integer.
- If the max threads specified by the CLI flag are active, the channel is not read from. A check is then performed every second in this situation.
- The Database connection is cloned for each thread. Concurrency is handled by `sea-orm` connection pooling and so no Mutex is required here. 
- The default concurrency is set to 4 (four threads to handle all the tasks generated by the active selection strategies)

### Additional notes

- [x] Tidy commits
- [x] Rebase on master ~~(currently rebased on PR 76 "record-audit-strategy" for testing)~~