### PR TITLE
construct EpochAccumulator from zero-th byte

### DIFF
--- a/glados-monitor/src/lib.rs
+++ b/glados-monitor/src/lib.rs
@@ -214,7 +214,7 @@ pub async fn import_pre_merge_accumulators(
                             Ok(content_key_raw) => {
                                 let content_key =
                                     HistoryContentKey::EpochAccumulator(EpochAccumulatorKey {
-                                        epoch_hash: H256::from_slice(&content_key_raw[1..]),
+                                        epoch_hash: H256::from_slice(&content_key_raw),
                                     });
                                 debug!(content_key = %content_key, "Importing");
                                 let content_key_db =


### PR DESCRIPTION
### Issue addressed

No associated issue

### Changes proposed

When importing the accumulator into `glados-monitor` use the block hash hex chars starting at index 0 rather than index 1.

### Description

This was noticed in passing while replacing hex utils. It appears that the function currently ignores the first character of the block hash. 