### PR TITLE
add http transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "tokio",
  "tracing",
  "trin-utils",
+ "url",
  "web3",
 ]
 
@@ -1896,12 +1897,17 @@ dependencies = [
  "ethereum-types 0.14.0",
  "ethportal-api",
  "jsonrpc",
+ "jsonrpsee",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustc-hex",
  "serde",
  "serde_json",
  "sha2 0.10.6",
  "thiserror",
  "tracing",
  "trin-utils",
+ "url",
 ]
 
 [[package]]

--- a/glados-audit/Cargo.toml
+++ b/glados-audit/Cargo.toml
@@ -24,3 +24,4 @@ trin-utils = {git = "https://github.com/ethereum/trin" }
 ethportal-api = { git = "https://github.com/ethereum/trin" }
 chrono = "0.4.23"
 rand = "0.8.5"
+url = "2.3.1"

--- a/glados-audit/src/cli.rs
+++ b/glados-audit/src/cli.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
+use url::Url;
 
 const DEFAULT_DB_URL: &str = "sqlite::memory:";
 
@@ -8,8 +9,12 @@ const DEFAULT_DB_URL: &str = "sqlite::memory:";
 pub struct Args {
     #[arg(short, long, default_value = DEFAULT_DB_URL)]
     pub database_url: String,
+    #[arg(short, long, requires = "transport")]
+    pub ipc_path: Option<PathBuf>,
+    #[arg(short = 'u', long, requires = "transport")]
+    pub http_url: Option<Url>,
     #[arg(short, long)]
-    pub ipc_path: PathBuf,
+    pub transport: TransportType,
     #[arg(short, long, default_value = "4", help = "number of auditing threads")]
     pub concurrency: u8,
 }
@@ -21,23 +26,44 @@ mod test {
     #[test]
     fn test_minimum_args() {
         const IPC_PATH: &str = "/path/to/ipc";
-        let result = Args::parse_from(["test", "--ipc-path", IPC_PATH]);
+        let result = Args::parse_from(["test", "--transport", "ipc", "--ipc-path", IPC_PATH]);
         let expected = Args {
             database_url: DEFAULT_DB_URL.to_string(),
-            ipc_path: PathBuf::from(IPC_PATH),
+            ipc_path: Some(PathBuf::from(IPC_PATH)),
             concurrency: 4,
+            http_url: None,
+            transport: TransportType::IPC,
         };
         assert_eq!(result, expected);
     }
     #[test]
     fn test_custom_concurrency() {
         const IPC_PATH: &str = "/path/to/ipc";
-        let result = Args::parse_from(["test", "--ipc-path", IPC_PATH, "--concurrency", "3"]);
+        let result = Args::parse_from([
+            "test",
+            "--transport",
+            "ipc",
+            "--ipc-path",
+            IPC_PATH,
+            "--concurrency",
+            "3",
+        ]);
         let expected = Args {
             database_url: DEFAULT_DB_URL.to_string(),
-            ipc_path: PathBuf::from(IPC_PATH),
+            ipc_path: Some(PathBuf::from(IPC_PATH)),
             concurrency: 3,
+            http_url: None,
+            transport: TransportType::IPC,
         };
         assert_eq!(result, expected);
     }
+}
+
+/// Used by a user to specify the intended form of transport
+/// to connect to a Portal node.
+#[derive(Debug, Clone, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum TransportType {
+    IPC,
+    HTTP,
 }

--- a/glados-audit/src/main.rs
+++ b/glados-audit/src/main.rs
@@ -1,11 +1,8 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
-use clap::Parser;
 use sea_orm::Database;
 use tracing::{debug, info};
 
-use glados_audit::{cli::Args, run_glados_audit};
+use glados_audit::{run_glados_audit, AuditConfig};
 use migration::{Migrator, MigratorTrait};
 
 #[tokio::main]
@@ -20,24 +17,25 @@ async fn main() -> Result<()> {
     //
     debug!("Parsing CLI arguments");
 
-    let args = Args::parse();
+    let config = AuditConfig::from_args()?;
 
     //
     // Database Connection
     //
-    debug!(database_url = &args.database_url, "Connecting to database");
+    debug!(
+        database_url = &config.database_url,
+        "Connecting to database"
+    );
 
-    let conn = Database::connect(&args.database_url).await?;
+    let conn = Database::connect(&config.database_url).await?;
 
     info!(
-        database_url = &args.database_url,
+        database_url = &config.database_url,
         "database connection established"
     );
 
     Migrator::up(&conn, None).await?;
 
-    let ipc_path: PathBuf = args.ipc_path;
-
-    run_glados_audit(conn, ipc_path, args.concurrency).await;
+    run_glados_audit(conn, config).await;
     Ok(())
 }

--- a/glados-audit/src/selection.rs
+++ b/glados-audit/src/selection.rs
@@ -96,6 +96,13 @@ async fn add_to_queue(
     strategy: SelectionStrategy,
     items: Vec<content::Model>,
 ) {
+    let capacity = tx.capacity();
+    let max_capacity = tx.max_capacity();
+    debug!(
+        channel.availability = capacity,
+        channel.size = max_capacity,
+        "Adding items to audit task channel."
+    );
     for content_key_model in items {
         // Create key from database bytes.
         let content_key = match HistoryContentKey::try_from(content_key_model.content_key) {

--- a/glados-core/Cargo.toml
+++ b/glados-core/Cargo.toml
@@ -21,3 +21,8 @@ env_logger = "0.9.3"
 tracing = "0.1.37"
 ethportal-api = { git = "https://github.com/ethereum/trin" }
 trin-utils = {git = "https://github.com/ethereum/trin" }
+url = "2.3.1"
+jsonrpsee = { version = "0.16.2", features = ["client"] }
+jsonrpsee-types = "0.16.2"
+rustc-hex = "2.1.0"
+jsonrpsee-core = "0.16.2"

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -1,90 +1,125 @@
+use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use trin_utils::bytes::hex_decode;
-#[cfg(windows)]
-use uds_windows::UnixStream;
-
-use std::path::Path;
+use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::{bail, Context, Result};
 use discv5::enr::CombinedKey;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::content_key::OverlayContentKey;
+use jsonrpc::{error::RpcError, Request};
+use jsonrpsee::{
+    core::{client::ClientT, params::ArrayParams},
+    http_client::{HttpClient, HttpClientBuilder},
+    rpc_params,
+};
 use serde::{Deserialize, Serialize};
-use serde_json::value::{to_raw_value, RawValue};
+use serde_json::{
+    json,
+    value::{to_raw_value, RawValue},
+    Value,
+};
 use thiserror::Error;
+use tracing::error;
+use trin_utils::bytes::hex_decode;
+#[cfg(windows)]
+use uds_windows::UnixStream;
+use url::Url;
 
 type Enr = discv5::enr::Enr<CombinedKey>;
 
-//
-// JSON RPC Client
-//
-fn build_request<'a>(
-    method: &'a str,
-    raw_params: &'a Option<Vec<Box<RawValue>>>,
+/// Configuration details for connection to a Portal network node.
+#[derive(Clone, Debug)]
+pub enum TransportConfig {
+    HTTP(Url),
+    IPC(PathBuf),
+}
+
+/// Details for a Connection to a Portal network node over different transports.
+pub enum PortalClient {
+    HTTP(HttpClientManager),
+    IPC(IpcClientManager),
+}
+
+/// HTTP-based transport for connecting to a Portal network node.
+pub struct HttpClientManager {
+    client: HttpClient,
+}
+
+/// IPC-based transport for connecting to a Portal network node.
+pub struct IpcClientManager {
+    stream: UnixStream,
     request_id: u64,
-) -> jsonrpc::Request<'a> {
-    match raw_params {
-        Some(val) => jsonrpc::Request {
-            method,
-            params: val,
-            id: serde_json::json!(request_id),
-            jsonrpc: Some("2.0"),
-        },
-        None => jsonrpc::Request {
-            method,
-            params: &[],
-            id: serde_json::json!(request_id),
-            jsonrpc: Some("2.0"),
-        },
-    }
-}
-
-pub trait TryClone {
-    fn try_clone(&self) -> Result<Self>
-    where
-        Self: Sized;
-}
-
-impl TryClone for UnixStream {
-    fn try_clone(&self) -> Result<Self> {
-        Ok(UnixStream::try_clone(self)?)
-    }
-}
-
-pub struct PortalClient<S>
-where
-    S: std::io::Read + std::io::Write + TryClone,
-{
-    stream: S,
-    request_id: u64,
-}
-
-impl PortalClient<UnixStream> {
-    pub fn from_ipc(path: &Path) -> Result<Self> {
-        Ok(Self {
-            stream: UnixStream::connect(path)
-                .with_context(|| format!("Could not open ipc file {}", path.display()))?,
-            request_id: 0,
-        })
-    }
 }
 
 #[derive(Error, Debug)]
 pub enum JsonRpcError {
-    #[error("Received malformed response: {0}")]
+    #[error("received formatted response with no error, but contains a None result")]
+    ContainsNone,
+
+    #[error("received empty response (EOF only)")]
+    Empty,
+
+    #[error("HTTP client error")]
+    HttpClient(#[from] jsonrpsee_core::Error),
+
+    #[error("received HTTP error code {source_err:?}")]
+    HttpResponse { source_err: RpcError }, // This source doesn't implement Error
+
+    /// Portal network defines "0x" as the response for absent content.
+    #[error("expected special 0x 'content absent' message for content request, received HTTP response with None result")]
+    SpecialMessageExpected,
+
+    /// Portal network defines "0x" as the response for absent content.
+    #[error("received special 0x 'content absent' message for non-content request, expected HTTP response with None result")]
+    SpecialMessageUnexpected,
+
+    #[error("unable to convert `{enr_string}` into ENR due to {error}")]
+    InvalidEnr {
+        error: String, // This source doesn't implement Error
+        enr_string: String,
+    },
+
+    #[error("unable to convert {input} to hash")]
+    InvalidHash {
+        source: rustc_hex::FromHexError,
+        input: String,
+    },
+
+    #[error("invalid integer conversion")]
+    InvalidIntegerConversion(#[from] std::num::TryFromIntError),
+
+    #[error("unable to convert string `{input}`")]
+    InvalidJson {
+        source: serde_json::Error,
+        input: String,
+    },
+
+    #[error("non-specific I/O error")]
+    IO(#[from] std::io::Error),
+
+    #[error("received malformed response: {0}")]
     Malformed(serde_json::Error),
 
-    #[error("Received empty response")]
-    Empty,
+    // todo remove once trin utils stops using nyhow.
+    #[error("Opaque error encountered")]
+    AnyhowError(#[from] anyhow::Error),
+
+    #[error("unable to serialize/deserialize")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("could not open file {path:?}")]
+    OpenFileFailed {
+        source: std::io::Error,
+        path: PathBuf,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct JsonRPCResult {
+pub struct JsonRPCResult {
     id: u32,
     jsonrpc: String,
-    result: serde_json::Value,
+    result: Value,
 }
 
 #[allow(non_snake_case)]
@@ -120,97 +155,192 @@ pub struct Content {
     pub raw: Vec<u8>,
 }
 
-// TryClone is used because JSON-RPC responses are not followed by EOF. We must read bytes
-// from the stream until a complete object is detected, and the simplest way of doing that
-// with available APIs is to give ownership of a Read to a serde_json::Deserializer. If we
-// gave it exclusive ownership that would require us to open a new connection for every
-// command we wanted to send! By making a clone (or, by trying to) we can have our cake
-// and eat it too.
-//
-// TryClone is not necessary if PortalClient stays in this file forever; this script only
-// needs to make a single request before it exits. However, in a future where PortalClient
-// becomes the mechanism other parts of the codebase (such as peertester) use to act as
-// JSON-RPC clients then this becomes necessary. So, this is slightly over-engineered but
-// with an eye to future growth.
-impl<'a, S> PortalClient<S>
-where
-    S: std::io::Read + std::io::Write + TryClone,
-{
-    fn build_request(
-        &mut self,
-        method: &'a str,
-        params: &'a Option<Vec<Box<RawValue>>>,
-    ) -> jsonrpc::Request<'a> {
-        let result = build_request(method, params, self.request_id);
-        self.request_id += 1;
+/// Differentiates content absent responses from other responses.
+/// Portal network specs define content absent by an "0x" response, which otherwise
+/// is not readily convertible to the Response type.
+#[derive(Clone, Debug)]
+pub enum PortalResponse {
+    ContentAbsent,
+    Regular(Value),
+}
 
-        result
-    }
-
-    fn make_request(&mut self, req: jsonrpc::Request) -> Result<JsonRPCResult> {
-        let data = serde_json::to_vec(&req)?;
-
-        self.stream.write_all(&data)?;
-        self.stream.flush()?;
-
-        let clone = self.stream.try_clone()?;
-        let deser = serde_json::Deserializer::from_reader(clone);
-
-        let Some(obj) = deser.into_iter::<JsonRPCResult>().next() else {
-            // this should only happen when they immediately send EOF
-            return Err(JsonRpcError::Empty)?
-        };
-        Ok(obj?)
-    }
-
-    pub fn get_client_version(&mut self) -> String {
-        let req = self.build_request("web3_clientVersion", &None);
-        let resp = self.make_request(req);
-
-        match resp {
-            Err(err) => format!("error: {err}"),
-            Ok(value) => value.result.to_string(),
+impl PortalResponse {
+    /// Creates a Portal response from an IPC/HTTP response result.
+    fn from_value(val: Value) -> Self {
+        match val.eq(&json!("0x")) {
+            true => PortalResponse::ContentAbsent,
+            false => PortalResponse::Regular(val),
         }
     }
 
-    pub fn get_node_info(&mut self) -> Result<NodeInfo> {
-        let req = self.build_request("discv5_nodeInfo", &None);
-        let resp = self.make_request(req)?;
-        Ok(serde_json::from_value(resp.result)?)
+    /// Converts a content response JSON value to a string.
+    ///
+    /// A valid content response may be None, unlike non-content responses.
+    /// This occurs through the special "0x" response defined in the Portal specs.
+    fn content_response_to_string(&self) -> Result<Option<String>, JsonRpcError> {
+        match self {
+            PortalResponse::ContentAbsent => Ok(None),
+            PortalResponse::Regular(response) => match response.as_str() {
+                None | Some("") => Err(JsonRpcError::ContainsNone),
+                Some("0x") => Err(JsonRpcError::SpecialMessageExpected),
+                Some(s) => Ok(Some(s.to_owned())),
+            },
+        }
+    }
+    /// Converts a non-content (e.g., node info) response JSON value to a string.
+    ///
+    /// A valid non-content response may be None, unlike content responses,
+    /// which must use the special "0x" response defined in the Portal specs.
+    fn non_content_response_to_string(&self) -> Result<String, JsonRpcError> {
+        match self {
+            PortalResponse::ContentAbsent => Err(JsonRpcError::SpecialMessageUnexpected),
+            PortalResponse::Regular(r) => Ok(r.to_string()),
+        }
+    }
+}
+
+impl PortalClient {
+    /// Returns a client to connect to a Portal network node.
+    pub fn from_config(config: &TransportConfig) -> Result<Self, JsonRpcError> {
+        Ok(match config {
+            TransportConfig::HTTP(http_url) => PortalClient::HTTP(HttpClientManager {
+                client: HttpClientBuilder::default().build(http_url.as_ref())?,
+            }),
+            TransportConfig::IPC(path) => PortalClient::IPC(IpcClientManager {
+                stream: UnixStream::connect(path).map_err(|e| JsonRpcError::OpenFileFailed {
+                    source: e,
+                    path: path.to_owned(),
+                })?,
+                request_id: 0,
+            }),
+        })
     }
 
-    pub fn get_routing_table_info(&mut self) -> Result<RoutingTableInfo> {
-        let req = self.build_request("discv5_routingTableInfo", &None);
-        let resp = self.make_request(req)?;
+    pub async fn make_request(
+        self,
+        method: &str,
+        params: Option<Vec<Box<RawValue>>>,
+    ) -> Result<PortalResponse, JsonRpcError> {
+        match self {
+            PortalClient::HTTP(http) => {
+                // jsonrpsee requires the conversion of `Option<Vec<Box<RawValue>>>` to `ArrayParams`
+                let array_params: ArrayParams = match params {
+                    Some(json_params) => {
+                        let mut param_aggregator = rpc_params!();
+                        for json_param in json_params {
+                            param_aggregator.insert(json_param).unwrap()
+                        }
+                        param_aggregator
+                    }
+                    None => rpc_params!(),
+                };
+                let val: Value = http.client.request(method, array_params).await?;
+                Ok(PortalResponse::from_value(val))
+            }
+            PortalClient::IPC(mut ipc) => {
+                let request = match &params {
+                    Some(raw_params) => Request {
+                        method,
+                        params: raw_params,
+                        id: serde_json::json!(ipc.request_id),
+                        jsonrpc: Some("2.0"),
+                    },
+                    None => Request {
+                        method,
+                        params: &[],
+                        id: serde_json::json!(ipc.request_id),
+                        jsonrpc: Some("2.0"),
+                    },
+                };
+                // Manually increment the request id after using it in the request.
+                ipc.request_id += 1;
 
-        let result_raw: RoutingTableInfoRaw = serde_json::from_value(resp.result)?;
-        let local_node_id = H256::from_str(&result_raw.localKey)?;
-        let buckets: Result<Vec<RoutingTableEntry>> = result_raw
+                let data = serde_json::to_vec(&request)?;
+                ipc.stream.write_all(&data)?;
+                ipc.stream.flush()?;
+
+                let response: JsonRPCResult =
+                    serde_json::Deserializer::from_reader(ipc.stream.try_clone()?)
+                        .into_iter()
+                        .next()
+                        // Empty response should only happen when they immediately send EOF
+                        .ok_or(JsonRpcError::Empty)??;
+                Ok(PortalResponse::from_value(response.result))
+            }
+        }
+    }
+
+    pub async fn get_client_version(self) -> Result<String, JsonRpcError> {
+        let method = "web3_clientVersion";
+        let params = None;
+        self.make_request(method, params)
+            .await?
+            .non_content_response_to_string()
+    }
+
+    pub async fn get_node_info(self) -> Result<NodeInfo, JsonRpcError> {
+        let method = "discv5_nodeInfo";
+        let params = None;
+        let response = self
+            .make_request(method, params)
+            .await?
+            .non_content_response_to_string()?;
+        serde_json::from_str(&response).map_err(|e| JsonRpcError::InvalidJson {
+            source: e,
+            input: response.to_string(),
+        })
+    }
+
+    pub async fn get_routing_table_info(self) -> Result<RoutingTableInfo, JsonRpcError> {
+        let method = "discv5_routingTableInfo";
+        let params = None;
+        let response = self
+            .make_request(method, params)
+            .await?
+            .non_content_response_to_string()?;
+        let result_raw: RoutingTableInfoRaw =
+            serde_json::from_str(&response).map_err(|e| JsonRpcError::InvalidJson {
+                source: e,
+                input: response.to_string(),
+            })?;
+        let local_node_id =
+            H256::from_str(&result_raw.localKey).map_err(|e| JsonRpcError::InvalidHash {
+                source: e,
+                input: result_raw.localKey.to_string(),
+            })?;
+        let buckets: Result<Vec<RoutingTableEntry>, JsonRpcError> = result_raw
             .buckets
             .iter()
             .map(|entry| parse_routing_table_entry(&local_node_id, &entry.0, &entry.1, &entry.2))
             .collect();
         Ok(RoutingTableInfo {
-            localKey: H256::from_str(&result_raw.localKey)?,
+            localKey: local_node_id,
             buckets: buckets?,
         })
     }
 
-    pub fn get_content<T: OverlayContentKey>(&mut self, content_key: &T) -> Result<Content> {
-        let params = Some(vec![to_raw_value(&content_key.to_hex())?]);
-        let req = self.build_request("portal_historyRecursiveFindContent", &params);
-        let resp = self.make_request(req)?;
-
-        let content_as_hex: String = serde_json::from_value(resp.result)?;
-        let content_raw = hex_decode(&content_as_hex)?;
-
-        Ok(Content { raw: content_raw })
+    pub async fn get_content<T: OverlayContentKey>(
+        self,
+        content_key: &T,
+    ) -> Result<Option<Content>, JsonRpcError> {
+        let method = "portal_historyRecursiveFindContent";
+        let key = &content_key.to_hex();
+        let param = to_raw_value(&key).map_err(|e| JsonRpcError::InvalidJson {
+            source: e,
+            input: key.to_string(),
+        })?;
+        match self
+            .make_request(method, Some(vec![param]))
+            .await?
+            .content_response_to_string()?
+        {
+            Some(response) => {
+                let content_raw = hex_decode(&response)?;
+                Ok(Some(Content { raw: content_raw }))
+            }
+            None => Ok(None),
+        }
     }
-
-    //fn get_node_enr(&mut self) -> Enr {
-    //    let node_info = self.get_node_info();
-    //    Enr::from_str(node_info.result.enr)?
-    //}
 }
 
 fn parse_routing_table_entry(
@@ -218,11 +348,16 @@ fn parse_routing_table_entry(
     raw_node_id: &str,
     encoded_enr: &str,
     status: &String,
-) -> Result<RoutingTableEntry> {
-    let node_id = H256::from_str(raw_node_id)?;
-    let Ok(enr) = Enr::from_str(encoded_enr) else {
-        bail!("Could not make ENR from string: {}", encoded_enr)
-    };
+) -> Result<RoutingTableEntry, JsonRpcError> {
+    let node_id = H256::from_str(raw_node_id).map_err(|e| JsonRpcError::InvalidHash {
+        source: e,
+        input: raw_node_id.to_string(),
+    })?;
+    let enr = Enr::from_str(encoded_enr).map_err(|e| JsonRpcError::InvalidEnr {
+        error: e,
+        enr_string: encoded_enr.to_string(),
+    })?;
+
     let distance = distance_xor(node_id.as_fixed_bytes(), local_node_id.as_fixed_bytes());
     let log_distance = distance_log2(distance)?;
     Ok(RoutingTableEntry {
@@ -242,7 +377,7 @@ fn distance_xor(x: &[u8; 32], y: &[u8; 32]) -> U256 {
     U256::from_big_endian(z.as_slice())
 }
 
-fn distance_log2(distance: U256) -> Result<u16> {
+fn distance_log2(distance: U256) -> Result<u16, JsonRpcError> {
     if distance.is_zero() {
         Ok(0)
     } else {

--- a/glados-core/src/jsonrpc.rs
+++ b/glados-core/src/jsonrpc.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use discv5::enr::CombinedKey;
 use ethereum_types::{H256, U256};
 use ethportal_api::types::content_key::OverlayContentKey;
-use jsonrpc::{error::RpcError, Request};
+use jsonrpc::Request;
 use jsonrpsee::{
     core::{client::ClientT, params::ArrayParams},
     http_client::{HttpClient, HttpClientBuilder},
@@ -62,9 +62,6 @@ pub enum JsonRpcError {
 
     #[error("HTTP client error")]
     HttpClient(#[from] jsonrpsee_core::Error),
-
-    #[error("received HTTP error code {source_err:?}")]
-    HttpResponse { source_err: RpcError }, // This source doesn't implement Error
 
     /// Portal network defines "0x" as the response for absent content.
     #[error("expected special 0x 'content absent' message for content request, received HTTP response with None result")]


### PR DESCRIPTION
## Issue addressed

- Closes #74 

## Proposed changes

Adds HTTP capability to `glados-audit`, where currently IPC exclusively supported. 
- The transport is selected with a new `--transport <ipc/http>`. 
- Transport configuration uses the existing `--ipc-path <path>` flag and a new `--http-url <url>` flag.
- New `AuditConfig` for holding config derived from parsed CLI arguments.

## Description

### CLI

This is the output from `cargo run -p glados-audit -- --help`

```console
Usage: glados-audit [OPTIONS] --transport <TRANSPORT>

Options:
  -d, --database-url <DATABASE_URL>  [default: sqlite::memory:]
  -i, --ipc-path <IPC_PATH>          
  -u, --http-url <HTTP_URL>          
  -t, --transport <TRANSPORT>        [possible values: ipc, http]
  -c, --concurrency <CONCURRENCY>    number of auditing threads [default: 4]
  -h, --help                         Print help information
  -V, --version                      Print version information
```

The transport flag is required. For the given transport variant (IPC/HTTP), if the corresponding path/url flag is not provided
an `error!()` is raised and the the audits do not start (`glados-audit` peacefully terminates)

### Configuration
New config built using the existing `clap`-based `Args` struct.
```rs
pub struct AuditConfig {
    /// Maximum amount of threads that audits will be performed with.
    pub concurrency: u8,
    /// For Glados-related data.
    pub database_url: String,
    /// For communication with a Portal Network node.
    pub transport: TransportConfig,
}
```
Where transport config is new and contains a transport-specific url/path.
```rs
pub enum TransportConfig {
    HTTP(Url),
    IPC(PathBuf),
}
```
### Client definition

The http method leverages the existing request code and introduces the change by converting the `PortalClient` struct into an enum. 
```rs
pub enum PortalClient {
    HTTP(HttpClient),
    IPC(IpcClient),
}
```
Where, when a new thread is created to complete an audit task, the aforementioned `TransportConfig` is used to create
a `let client = PortalClient::from_config()`. The request made using the existing method called `client.make_request(method, params)`.

The enum variants house the details required for sockets/http/ids as follows:
```
pub struct HttpClient {
    client: Client, // jsonrpsee async HTTP client
    // No request id as the client auto-increments.
}

pub struct IpcClient {
    stream: UnixStream, // existing IPC client
    request_id: u64,
}
```
### Response handling
Responses for HTTP (jsonrpsee crate) and IPC (`serde_json`-parsed locally-defined `JsonRPCResult`) are different. They are unified by an enum (`PortalResponse`) so that making a client request can be abstracted from the transport kind.
```rs
pub enum PortalResponse {
    ContentAbsent, // special case defined in portal network ("0x" == "no content")
    Regular(Value), // serde_json::Value
}
```
### Dependencies
The `jsonrpsee` crate is used for the client because it is used in `Trin`.

### Performance
The http client and ipc sockets are discarded after every request. This follows the concurrency model where tasks are
spawned in new threads, they create a connection and then conclude, terminating that connection. 

### Concurrency parsing
When the new `AuditConfig` struct is created a new check is introduced that reads available parallelism on the system via:
```rs
let parallelism = std::thread::available_parallelism()?.get();
```
A `warn!` is raised if the user passes a concurrency flag greater than this value. 
While this could be a separate PR, I have included it here because it is useful in testing to see what threads are available for the http client to use and is a minimal change. 

### Error handling in `glados-core::json_rpc`

All instances of error handling with `anyhow::Error` are replaced by custom `thiserror::Error` enum variants. This is to increase error clarity and information contextual available as `glados-core` is effectively used as a library by `glados-audit`.

### Additional notes

- [x] Investigate switching to IPC to jsonrpsee to simplify response handling. Result: Encountered a few issues not readily resolved. Simplification introduced by other means. Conclusion: Could be the subject of a different PR if desired.
- [x] Testing
    - [x] Flag usage 
    - [x] IPC with Trin functional
    - [x] HTTP with Trin functional 
- [x] Rebase on master once 81 is merged
     - Currently built on top of: #81 for testing.
- [x] Raised #92