### PR TITLE
fix rate display

### DIFF
--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -395,16 +395,8 @@ async fn get_audit_stats(period: Period, conn: &DatabaseConnection) -> Result<St
         new_content,
         total_audits,
         total_passes,
-        passes_per_100: rate(total_passes, total_audits),
+        passes_per_100: (100 * total_passes).checked_div(total_audits).unwrap_or(0),
         total_failures,
-        failures_per_100: rate(total_failures, total_audits),
+        failures_per_100: (100 * total_failures).checked_div(total_audits).unwrap_or(0),
     })
-}
-
-/// Returns rate as integer. E.g., 5% as 5u32
-fn rate(dividend: u32, divisor: u32) -> u32 {
-    match (100 * dividend).checked_div(divisor) {
-        Some(fraction) => fraction,
-        None => 0,
-    }
 }

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -403,8 +403,8 @@ async fn get_audit_stats(period: Period, conn: &DatabaseConnection) -> Result<St
 
 /// Returns rate as integer. E.g., 5% as 5u32
 fn rate(dividend: u32, divisor: u32) -> u32 {
-    match dividend.checked_div(divisor) {
-        Some(fraction) => 100 * fraction,
+    match (100 * dividend).checked_div(divisor) {
+        Some(fraction) => fraction,
         None => 0,
     }
 }

--- a/glados-web/src/routes.rs
+++ b/glados-web/src/routes.rs
@@ -397,6 +397,8 @@ async fn get_audit_stats(period: Period, conn: &DatabaseConnection) -> Result<St
         total_passes,
         passes_per_100: (100 * total_passes).checked_div(total_audits).unwrap_or(0),
         total_failures,
-        failures_per_100: (100 * total_failures).checked_div(total_audits).unwrap_or(0),
+        failures_per_100: (100 * total_failures)
+            .checked_div(total_audits)
+            .unwrap_or(0),
     })
 }

--- a/glados-web/templates/content_dashboard.html
+++ b/glados-web/templates/content_dashboard.html
@@ -29,8 +29,8 @@
                             <td>{{ stat.total_audits }}</td>
                             <td>{{ stat.total_passes }}</td>
                             <td>{{ stat.total_failures }}</td>
-                            <td>{{ stat.passes_per_100 }}</td>
-                            <td>{{ stat.failures_per_100 }}</td>
+                            <td>{{ stat.passes_per_100 }}%</td>
+                            <td>{{ stat.failures_per_100 }}%</td>
                         </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
Fix the "rate" calculation for `glados-web` displaying audit stats.  Was previously always showing 0% due to order of operations.