### PR TITLE
stop collation if one strategy closes

### DIFF
--- a/glados-audit/src/lib.rs
+++ b/glados-audit/src/lib.rs
@@ -12,7 +12,7 @@ use cli::Args;
 use ethportal_api::{HistoryContentKey, OverlayContentKey};
 use sea_orm::DatabaseConnection;
 use tokio::{
-    sync::mpsc::{self, Receiver},
+    sync::mpsc::{self, error::TryRecvError, Receiver},
     time::{sleep, Duration},
 };
 use tracing::{debug, error, info};
@@ -165,7 +165,10 @@ async fn start_collation(
                         .send(task)
                         .await
                         .expect("Unable to collate task"),
-                    Err(_) => break,
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        panic!("Unable to receive task for collation")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What was wrong

Absent handling of case where strategy channel is closed. The collation would continue, silently skipping that strategy.

## What was changed

Terminate collation if any one strategy is unable to continue.